### PR TITLE
Fix Drone setup

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -10,7 +10,7 @@ steps:
     dry_run: true
     purge: true
 - name: test
-  image: madnificent/ember:3.20.0
+  image: danlynn/ember-cli:3.20.0
   commands:
   - npm install
   - npm test


### PR DESCRIPTION
Old Drone setup did not have support for testing with headless Chrome. I know it is a bit silly, since there are no tests for this repository, but even some implicit test (to make sure assert are working properly) fails.
Another possibility is to outright disable all tests in the Drone setup, but maybe not a good idea for future proofing.