### PR TITLE
Cleanup: remove plugin checkboxes

### DIFF
--- a/public/test.html
+++ b/public/test.html
@@ -29,12 +29,6 @@
         Insert besluit template
       </button>
       <div>
-        Plugins:
-        <input type="checkbox" id="plugin-besluit" value="besluit" checked="checked" /> besluit
-        <input type="checkbox" id="plugin-citaat" value="citaten-plugin" checked="checked" /> citaten
-        <input type="checkbox" id="plugin-roadsign" value="roadsign-regulation" checked="checked" /> mobiliteitsmaatregelen
-        <input type="checkbox" id="plugin-variable" value="template-variable" checked="checked" /> template variabelen
-        <br>
         Environment banner
         <input type="checkbox" id="environment-banner" checked="checked" /> 
       </div>


### PR DESCRIPTION
fixes [GN-4221](https://binnenland.atlassian.net/browse/GN-4221?atlOrigin=eyJpIjoiNTdiNDRkYTA4MTNhNGMyN2ExOTBkYjAxNzJiOGZlYjQiLCJwIjoiaiJ9)

On the public/test.html page, some checkboxes were present to enable/disable plugins, but were not hooked up to any code (=> did nothing). These are now removed.