### PR TITLE
[CI/CD] Add prebuilt packages automatically in github for every release

### DIFF
--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -3,6 +3,7 @@ pipeline:
     image: danlynn/ember-cli:4.8.0
     commands:
       - npm ci
+      - ember build -prod
   release:
     image: plugins/npm
     settings:
@@ -15,6 +16,18 @@ pipeline:
       tags: "${CI_COMMIT_TAG##v}"
       secrets: [ docker_username, docker_password ]
       purge: true
+  publish:
+    image: plugins/github-release
+    settings:
+      api-key: 
+        from_secret: github_api_key
+      files: 
+        - dist/assets/frontend-embeddable-notule-editor-app.js 
+        - dist/assets/frontend-embeddable-notule-editor.css 
+        - dist/assets/frontend-embeddable-notule-editor.js
+        - dist/assets/vendor.js
+        # vendor.css is empty as this point. Github releases does not accept empty files.
+        #- dist/assets/vendor.css
 when:
   event: tag
   tag: v*

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ not be saved.
 The prebuilt bundles are currently hosted on `https://embeddable.gelinkt-notuleren.lblod.info/`.
 For information on how to include them in your html file, see the [target usage](#target-usage) section below.
 This is considered a test environment and is subject to change, so it is not recommended to use it in production.
-A stable hosted package solution is being worked on in the meantime.
 
+For production, use the prebuilt packages in the [Github releases](https://github.com/lblod/frontend-embeddable-notule-editor/releases/). At this point `vendor.css` is empty and is not added to the release. It can be ignored.
 
 ⚠️When using the prebuilt sources, the citation plugin will not yet work. We are working on resolving this ASAP.⚠️
 


### PR DESCRIPTION
issue [GN-4306: Add prebuilt packages to github releases of embeddable](https://binnenland.atlassian.net/browse/GN-4306)

The source is built and afterwards it is uploaded to github releases via the github-release plugin. 

Notes:
- At first I wanted to use the files created by the docker plugin, as the dockerFile also builds the source. Both to keep it in parity if some special things had to happen (currently not the case though) and to avoid `ember build -prod` having to run two times in the CI. I couldn't get this to work, so now it is the more straightforward and logical solution. A release doesn't happen often so it really doesn't matter a lot.
- `vendor.css` is empty, which Github doesn't accept to be uploaded in a release (an empty file makes no sense). Easiest solution is to just not serve it. I added a comment in the woodpecker file and updated the readme, to hopefully avoid any confusion it might create.
- it has been tested on a separate repository (fork). 
- **important** `github_api_key` has to be added to woodpecker. Note that this api key needs to be able to add files (_write_) to releases. 

