### PR TITLE
Use au-modal-container component

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,3 +1,4 @@
 {{page-title "Embeddable RDFa Editor"}}
+<AuModalContainer />
 <SimpleEditor @model={{@model}}/>
 {{outlet}}

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -21,6 +21,9 @@ module.exports = function (defaults) {
         ],
       },
     },
+    '@appuniversum/ember-appuniversum': {
+      disableWormholeElement: true,
+    },
   });
 
   // Use `app.import` to add additional libraries to the generated


### PR DESCRIPTION
## Overview
This PR adds the `au-modal-container` component to the `application.hbs` file, which is the new way to display ember-appuniversum modals.