### PR TITLE
GN-4483: Remove styling for `#ember-basic-dropdown-wormhole`

### DIFF
--- a/public/assets/demo.css
+++ b/public/assets/demo.css
@@ -20,8 +20,3 @@ body {
 .notule-editor {
   height: 100%;
 }
-
-
-.notule-editor #ember-basic-dropdown-wormhole {
-  position: static;
-}


### PR DESCRIPTION
### Overview

Remove styling for `#ember-basic-dropdown-wormhole` as it _may_ break the styling for applications embedding the editor.

#### Connected issues and PRs

https://binnenland.atlassian.net/browse/GN-4483


### Setup

1. Checkout https://github.com/lblod/ember-rdfa-editor/pull/958
2. Checkout this PR
3. In the `embeddable` repo do a `npm link ../ember-rdfa-editor/` (depends on where you have the editor checked out)
4. In the `embeddable` repo `npm run start`

### How to test/reproduce

* Observe that the dropdown for the `Inline variable` renders in the correct place when fix from the editor is npm linked
  <img width="1277" alt="CleanShot 2023-09-05 at 11 56 31@2x" src="https://github.com/lblod/ember-rdfa-editor/assets/769698/380c8f1c-6039-40cf-b0fb-b257a1e3629e">

* Observe that the dropdown is rendered in the wrong place when the fix from the editor is not npm linked 

<img width="1274" alt="CleanShot 2023-09-05 at 11 59 50@2x" src="https://github.com/lblod/ember-rdfa-editor/assets/769698/a0c6f34c-2b5e-48a6-8a35-20222340d447">


### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
