### PR TITLE
Bugfix: load controller correctly so it is accessible for the consumer

### DIFF
--- a/.changeset/cool-walls-jog.md
+++ b/.changeset/cool-walls-jog.md
@@ -1,0 +1,6 @@
+---
+'frontend-embeddable-notule-editor': minor
+---
+
+- Bugfix: controller is now loaded correctly to the `editorElement` and can be used.
+- On/Off methods bound to the `editorElement` are removed, as they are methods that didn't do anything.

--- a/app/components/simple-editor.js
+++ b/app/components/simple-editor.js
@@ -119,22 +119,25 @@ export default class SimpleEditorComponent extends Component {
 
   @action
   handleRdfaEditorInit(controller) {
+    // This, together with `insertedInDom` adds the public-facing logic available to the consumer.
+    // This includes the controller with most of the functionality
+    // and some other helper functions for easy accessing.
     this.controller = controller;
+    this.editorElement.getHtmlContent = this.getHtmlContent;
+    this.editorElement.setHtmlContent = this.setHtmlContent;
+    this.editorElement.controller = this.controller;
   }
 
   @action
   insertedInDom(element) {
     this.setVocab(element);
     this.setPrefix(element);
-    // This is the public-facing logic available to the consumer.
-    // This includes the controller with most of the functionality
-    // and some other helper functions for easy accessing.
-    element.getHtmlContent = this.getHtmlContent;
-    element.setHtmlContent = this.setHtmlContent;
-    element.controller = this.controller;
-    element.initEditor = this.initEditor;
-    element.enableEnvironmentBanner = this.enableEnvironmentBanner;
-    element.disableEnvironmentBanner = this.disableEnvironmentBanner;
+    this.editorElement = element;
+    // `insertedInDom` will run before `handleRdfaEditorInit`, which gives access to the controller
+    // these methods can be used before the controller has been loaded
+    this.editorElement.initEditor = this.initEditor;
+    this.editorElement.enableEnvironmentBanner = this.enableEnvironmentBanner;
+    this.editorElement.disableEnvironmentBanner = this.disableEnvironmentBanner;
   }
 
   /**

--- a/app/components/simple-editor.js
+++ b/app/components/simple-editor.js
@@ -132,8 +132,6 @@ export default class SimpleEditorComponent extends Component {
     element.getHtmlContent = this.getHtmlContent;
     element.setHtmlContent = this.setHtmlContent;
     element.controller = this.controller;
-    element.on = this.on;
-    element.off = this.off;
     element.initEditor = this.initEditor;
     element.enableEnvironmentBanner = this.enableEnvironmentBanner;
     element.disableEnvironmentBanner = this.disableEnvironmentBanner;
@@ -177,16 +175,6 @@ export default class SimpleEditorComponent extends Component {
   @action
   disableEnvironmentBanner() {
     this.showEnvironmentBanner = false;
-  }
-
-  @action
-  on(eventName, callback) {
-    this.controller.on(eventName, callback);
-  }
-
-  @action
-  off(eventName, callback) {
-    this.controller.off(eventName, callback);
   }
 
   @action


### PR DESCRIPTION
## Overview
Before the controller (via `editorElement.controller`) would be undefined, so consumers could do nothing, except for the functions directly available on `editorElement` (which is basically setting and getting html).
This fixes it so the controller is available and everything prosemirror-wise can be accessed.

It also removes the on/off functions, as these event handlers are a thing of the past as far as I could find.

##### connected issues and PRs:
No ticket, was found while rewriting documentation

### How to test/reproduce
Before controller was undefined. Now it isn't.
One way to check this is to inspect the page, right click on the div with class `notule-editor` (this is the `editorElement`) and click "use in console" or "store as global variable" (for firefox/chrome).

### Challenges/uncertainties
I didn't want to make any assumptions about when the controller would be loaded (although it seemed consistent that insertedInDom happens before handleRdfaEditorInit).
So the functions that need a controller are added when the controller exists.

Currently the user can't know if the controller is loaded (it might not be when running initEditor?), but in practice I don't think this will ever be a problem.