### PR TITLE
GN-4510: Keep default values of config where user config is not specified

### DIFF
--- a/.changeset/orange-bugs-sort.md
+++ b/.changeset/orange-bugs-sort.md
@@ -1,0 +1,5 @@
+---
+'frontend-embeddable-notule-editor': patch
+---
+
+GN-4510: Keep default values of config where user config is not specified

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,6 @@ updates:
     schedule:
       interval: daily
     labels:
+    ``- "dependabot"
       - "internal"
     rebase-strategy: "disabled"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ The readme is structured as follows
 - [Editor API](editor-api): list of methods and properties to customize the editor and interact with it through code.
 - [Configuring The Editor](configuring-the-editor): ways to configure the editor during loading. The editor includes a list of plugins that can be enabled and configured as explained in [Managing Plugins](managing-plugins). 
 
-
 ## Live Demo
 A [live demo](https://embeddable.gelinkt-notuleren.lblod.info) is available for easy testing. 
 This environment is NOT suited for any production use, as it might change without notice and might be an outdated version. 
@@ -197,8 +196,8 @@ The editor can be customized to best fit your application.
 Embeddable ships with the following plugins available. 
 This Readme contains all the important info and configuration for the plugins. For more technical and Ember-specific explanations of every plugin, you can check out the Readme of [lblod/ember-rdfa-editor-lblod-plugins](https://github.com/lblod/ember-rdfa-editor-lblod-plugins).
 
-Every plugin can be enabled by passing its name to the `arrayOfPluginNames` array and its configuration to `userConfigObject` with the initialization function `initEditor(arrayOfPluginNames, userConfigObject)`.
-> :warning: The values shown for the config are default values used if you do not pass a config. If you pass **any** config for a plugin, it will not use any of these defaults and only use the config provided. Make sure to pass all required attributes in this case, even if you do not change them.
+Every plugin can be enabled by passing its name to the `arrayOfPluginNames` array and optionally its configuration to `userConfigObject` with the initialization function `initEditor(arrayOfPluginNames, userConfigObject)`. 
+Any configuration value not provided will use the default value, which are shown in the example configs of the plugins.
 
 * [article-structure](#article-structure): Provides structures to better manage official documents, like titles, chapters, articles and paragraphs. It allows you to insert, move and delete them. It has two modes: `besluit` for besluit articles and `regulatoryStatement` for all other structures.
 * [besluit](#besluit): Provides the correct rdfa-structure for constructing a decision ("besluiten") and some basic validation which checks whether mandatory structures are present in the document.

--- a/app/components/simple-editor.js
+++ b/app/components/simple-editor.js
@@ -2,14 +2,17 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
-import merge from 'lodash.mergewith';
 
 import { Schema } from '@lblod/ember-rdfa-editor';
 
-import { linkPasteHandler } from '@lblod/ember-rdfa-editor/plugins/link';
 import {
-  tableOfContentsView,
+  link,
+  linkPasteHandler,
+  linkView,
+} from '@lblod/ember-rdfa-editor/plugins/link';
+import {
   table_of_contents,
+  tableOfContentsView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/table-of-contents-plugin/nodes';
 import { firefoxCursorFix } from '@lblod/ember-rdfa-editor/plugins/firefox-cursor-fix';
 import { lastKeyPressedPlugin } from '@lblod/ember-rdfa-editor/plugins/last-key-pressed';
@@ -23,8 +26,8 @@ import {
   underline,
 } from '@lblod/ember-rdfa-editor/plugins/text-style';
 import {
-  docWithConfig,
   block_rdfa,
+  docWithConfig,
   hard_break,
   horizontal_rule,
   invisible_rdfa,
@@ -73,7 +76,6 @@ import {
 import { citationPlugin } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin';
 
 import { roadsign_regulation } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/roadsign-regulation-plugin/nodes';
-import { link, linkView } from '@lblod/ember-rdfa-editor/plugins/link';
 import { highlight } from '@lblod/ember-rdfa-editor/plugins/highlight/marks/highlight';
 import { color } from '@lblod/ember-rdfa-editor/plugins/color/marks/color';
 
@@ -86,99 +88,22 @@ import {
   addressView,
   codelist,
   codelistView,
-  number,
-  numberView,
   location,
   locationView,
+  number,
+  numberView,
   text_variable,
   textVariableView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/variables';
 
-const mergeCustomizer = (objValue, srcValue) => {
-  if (Array.isArray(objValue) && Array.isArray(srcValue)) {
-    return srcValue;
-  }
-};
-
-/**
- * If the user config is present, merge it with the default config.
- * Otherwise return the default config.
- * @param defaultConfig
- * @param userConfig
- * @returns {*}
- */
-const mergeConfigs = (defaultConfig, userConfig) => {
-  if (userConfig) {
-    return merge(defaultConfig, userConfig, mergeCustomizer);
-  }
-
-  return defaultConfig;
-};
-
-/**
- * @type {import('@lblod/ember-rdfa-editor-lblod-plugins/plugins/rdfa-date-plugin/index').DateOptions}
- */
-const defaultRdfaDatePluginConfig = (t) => ({
-  placeholder: {
-    insertDate: t('date-plugin.insert.date'),
-    insertDateTime: t('date-plugin.insert.datetime'),
-  },
-  formats: [
-    {
-      label: 'Short Date',
-      key: 'short',
-      dateFormat: 'dd/MM/yy',
-      dateTimeFormat: 'dd/MM/yy HH:mm',
-    },
-    {
-      label: 'Long Date',
-      key: 'long',
-      dateFormat: 'EEEE dd MMMM yyyy',
-      dateTimeFormat: 'PPPPp',
-    },
-  ],
-  allowCustomFormat: true,
-});
-
-/**
- * @type {import('@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin').CitationPluginEmberComponentConfig}
- */
-const defaultCitationPluginConfig = {
-  type: 'ranges',
-  activeInRanges: (state) => [[0, state.doc.content.size]],
-  endpoint: '/codex/sparql',
-};
-
-/**
- * @type {import('@lblod/ember-rdfa-editor-lblod-plugins/plugins/roadsign-regulation-plugin').RoadsignRegulationPluginOptions}
- */
-const defaultRoadsignRegulationPluginConfig = {
-  endpoint: 'https://dev.roadsigns.lblod.info/sparql',
-  imageBaseUrl: 'https://register.mobiliteit.vlaanderen.be/',
-};
-
-/**
- * @type {import("@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/location/edit").LocationEditOptions}
- */
-const defaultLocationVariablePluginConfig = {
-  endpoint: 'https://dev.roadsigns.lblod.info/sparql',
-  zonalLocationCodelistUri:
-    'http://lblod.data.gift/concept-schemes/62331E6900730AE7B99DF7EF',
-  nonZonalLocationCodelistUri:
-    'http://lblod.data.gift/concept-schemes/62331FDD00730AE7B99DF7F2',
-};
-
-/**
- * @type {import("@lblod/ember-rdfa-editor-lblod-plugins/plugins/table-of-contents-plugin").TableOfContentsConfig}
- */
-const defaultTableOfContentsPluginConfig = [
-  {
-    nodeHierarchy: [
-      'title|chapter|section|subsection|article',
-      'structure_header|article_header',
-    ],
-  },
-];
+import {
+  defaultCitationPluginConfig,
+  defaultLocationVariablePluginConfig,
+  defaultRdfaDatePluginConfig,
+  defaultRoadsignRegulationPluginConfig,
+  defaultTableOfContentsPluginConfig,
+  mergeConfigs,
+} from '../config/defaults';
 
 export default class SimpleEditorComponent extends Component {
   @tracked controller;

--- a/app/components/simple-editor.js
+++ b/app/components/simple-editor.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
-import merge from 'lodash.merge';
+import merge from 'lodash.mergewith';
 
 import { Schema } from '@lblod/ember-rdfa-editor';
 
@@ -94,6 +94,12 @@ import {
   textVariableView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/variables';
 
+const mergeCustomizer = (objValue, srcValue) => {
+  if (Array.isArray(objValue) && Array.isArray(srcValue)) {
+    return srcValue;
+  }
+};
+
 /**
  * If the user config is present, merge it with the default config.
  * Otherwise return the default config.
@@ -101,9 +107,9 @@ import {
  * @param userConfig
  * @returns {*}
  */
-const maybeMergeUserConfig = (defaultConfig, userConfig) => {
+const mergeConfigs = (defaultConfig, userConfig) => {
   if (userConfig) {
-    return merge(defaultConfig, userConfig);
+    return merge(defaultConfig, userConfig, mergeCustomizer);
   }
 
   return defaultConfig;
@@ -352,7 +358,7 @@ export default class SimpleEditorComponent extends Component {
   }
 
   setupDatePlugin({ nodes, userConfig, config, nodeViews }) {
-    config.date = maybeMergeUserConfig(
+    config.date = mergeConfigs(
       defaultRdfaDatePluginConfig(this.intl.t.bind(this.intl)),
       userConfig.date
     );
@@ -362,7 +368,7 @@ export default class SimpleEditorComponent extends Component {
   }
 
   setupCitationPlugin({ userConfig, config, plugins }) {
-    config.citation = maybeMergeUserConfig(
+    config.citation = mergeConfigs(
       defaultCitationPluginConfig,
       userConfig.citation
     );
@@ -394,7 +400,7 @@ export default class SimpleEditorComponent extends Component {
 
     nodes.roadsign_regulation = roadsign_regulation;
 
-    config.roadsignRegulation = maybeMergeUserConfig(
+    config.roadsignRegulation = mergeConfigs(
       defaultRoadsignRegulationPluginConfig,
       userConfig.roadsignRegulation
     );
@@ -467,7 +473,7 @@ export default class SimpleEditorComponent extends Component {
     }
 
     if (config.variable.edit.enable) {
-      config.variable.edit.location = maybeMergeUserConfig(
+      config.variable.edit.location = mergeConfigs(
         defaultLocationVariablePluginConfig,
         userConfig.variable?.edit?.location
       );

--- a/app/components/simple-editor.js
+++ b/app/components/simple-editor.js
@@ -168,6 +168,18 @@ const defaultLocationVariablePluginConfig = {
     'http://lblod.data.gift/concept-schemes/62331FDD00730AE7B99DF7F2',
 };
 
+/**
+ * @type {import("@lblod/ember-rdfa-editor-lblod-plugins/plugins/table-of-contents-plugin").TableOfContentsConfig}
+ */
+const defaultTableOfContentsPluginConfig = [
+  {
+    nodeHierarchy: [
+      'title|chapter|section|subsection|article',
+      'structure_header|article_header',
+    ],
+  },
+];
+
 export default class SimpleEditorComponent extends Component {
   @tracked controller;
 
@@ -496,14 +508,11 @@ export default class SimpleEditorComponent extends Component {
   setupTOCPlugin(setup) {
     const { config, userConfig, nodes, nodeViews } = setup;
 
-    config.tableOfContents = userConfig.tableOfContents ?? [
-      {
-        nodeHierarchy: [
-          'title|chapter|section|subsection|article',
-          'structure_header|article_header',
-        ],
-      },
-    ];
+    config.tableOfContents = mergeConfigs(
+      defaultTableOfContentsPluginConfig,
+      userConfig.tableOfContents
+    );
+
     nodes.table_of_contents = table_of_contents(config.tableOfContents);
 
     nodeViews.table_of_contents = (controller) =>

--- a/app/components/simple-editor.js
+++ b/app/components/simple-editor.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
+import merge from 'lodash.merge';
 
 import { Schema } from '@lblod/ember-rdfa-editor';
 
@@ -92,6 +93,75 @@ import {
   text_variable,
   textVariableView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/variables';
+
+/**
+ * If the user config is present, merge it with the default config.
+ * Otherwise return the default config.
+ * @param defaultConfig
+ * @param userConfig
+ * @returns {*}
+ */
+const maybeMergeUserConfig = (defaultConfig, userConfig) => {
+  if (userConfig) {
+    return merge(defaultConfig, userConfig);
+  }
+
+  return defaultConfig;
+};
+
+/**
+ * @type {import('@lblod/ember-rdfa-editor-lblod-plugins/plugins/rdfa-date-plugin/index').DateOptions}
+ */
+const defaultRdfaDatePluginConfig = (t) => ({
+  placeholder: {
+    insertDate: t('date-plugin.insert.date'),
+    insertDateTime: t('date-plugin.insert.datetime'),
+  },
+  formats: [
+    {
+      label: 'Short Date',
+      key: 'short',
+      dateFormat: 'dd/MM/yy',
+      dateTimeFormat: 'dd/MM/yy HH:mm',
+    },
+    {
+      label: 'Long Date',
+      key: 'long',
+      dateFormat: 'EEEE dd MMMM yyyy',
+      dateTimeFormat: 'PPPPp',
+    },
+  ],
+  allowCustomFormat: true,
+});
+
+/**
+ * @type {import('@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin').CitationPluginEmberComponentConfig}
+ */
+const defaultCitationPluginConfig = {
+  type: 'ranges',
+  activeInRanges: (state) => [[0, state.doc.content.size]],
+  endpoint: '/codex/sparql',
+};
+
+/**
+ * @type {import('@lblod/ember-rdfa-editor-lblod-plugins/plugins/roadsign-regulation-plugin').RoadsignRegulationPluginOptions}
+ */
+const defaultRoadsignRegulationPluginConfig = {
+  endpoint: 'https://dev.roadsigns.lblod.info/sparql',
+  imageBaseUrl: 'https://register.mobiliteit.vlaanderen.be/',
+};
+
+/**
+ * @type {import("@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/location/edit").LocationEditOptions}
+ */
+const defaultLocationVariablePluginConfig = {
+  endpoint: 'https://dev.roadsigns.lblod.info/sparql',
+  zonalLocationCodelistUri:
+    'http://lblod.data.gift/concept-schemes/62331E6900730AE7B99DF7EF',
+  nonZonalLocationCodelistUri:
+    'http://lblod.data.gift/concept-schemes/62331FDD00730AE7B99DF7F2',
+};
+
 export default class SimpleEditorComponent extends Component {
   @tracked controller;
 
@@ -282,46 +352,21 @@ export default class SimpleEditorComponent extends Component {
   }
 
   setupDatePlugin({ nodes, userConfig, config, nodeViews }) {
-    if (!userConfig.date) {
-      config.date = {
-        placeholder: {
-          insertDate: this.intl.t('date-plugin.insert.date'),
-          insertDateTime: this.intl.t('date-plugin.insert.datetime'),
-        },
-        formats: [
-          {
-            label: 'Short Date',
-            key: 'short',
-            dateFormat: 'dd/MM/yy',
-            dateTimeFormat: 'dd/MM/yy HH:mm',
-          },
-          {
-            label: 'Long Date',
-            key: 'long',
-            dateFormat: 'EEEE dd MMMM yyyy',
-            dateTimeFormat: 'PPPPp',
-          },
-        ],
-        allowCustomFormat: true,
-      };
-    } else {
-      config.date = userConfig.date;
-    }
+    config.date = maybeMergeUserConfig(
+      defaultRdfaDatePluginConfig(this.intl.t.bind(this.intl)),
+      userConfig.date
+    );
+
     nodes.date = date(config.date);
     nodeViews.date = (controller) => dateView(this.config.date)(controller);
   }
 
   setupCitationPlugin({ userConfig, config, plugins }) {
-    const citationConfig = userConfig.citation;
-    if (citationConfig) {
-      config.citation = citationConfig;
-    } else {
-      config.citation = {
-        type: 'ranges',
-        activeInRanges: (state) => [[0, state.doc.content.size]],
-        endpoint: '/codex/sparql',
-      };
-    }
+    config.citation = maybeMergeUserConfig(
+      defaultCitationPluginConfig,
+      userConfig.citation
+    );
+
     const citationPluginVariable = citationPlugin(config.citation);
     this.citationPlugin = citationPluginVariable;
     plugins.push(citationPluginVariable);
@@ -348,10 +393,11 @@ export default class SimpleEditorComponent extends Component {
     const { nodes, config, userConfig } = setup;
 
     nodes.roadsign_regulation = roadsign_regulation;
-    config.roadsignRegulation = userConfig.roadsignRegulation ?? {
-      endpoint: 'https://dev.roadsigns.lblod.info/sparql',
-      imageBaseUrl: 'https://register.mobiliteit.vlaanderen.be/',
-    };
+
+    config.roadsignRegulation = maybeMergeUserConfig(
+      defaultRoadsignRegulationPluginConfig,
+      userConfig.roadsignRegulation
+    );
   }
 
   setupVariablePlugin(setup) {
@@ -421,18 +467,13 @@ export default class SimpleEditorComponent extends Component {
     }
 
     if (config.variable.edit.enable) {
-      config.variable.edit.location = {
-        endpoint:
-          userConfig.variable?.edit?.location?.endpoint ??
-          'https://dev.roadsigns.lblod.info/sparql',
-        zonalLocationCodelistUri:
-          userConfig.variable?.edit?.location?.zonalLocationCodelistUri ??
-          'http://lblod.data.gift/concept-schemes/62331E6900730AE7B99DF7EF',
-        nonZonalLocationCodelistUri:
-          userConfig.variable?.edit?.loation?.nonZonalLocationCodelistUri ??
-          'http://lblod.data.gift/concept-schemes/62331FDD00730AE7B99DF7F2',
-      };
+      config.variable.edit.location = maybeMergeUserConfig(
+        defaultLocationVariablePluginConfig,
+        userConfig.variable?.edit?.location
+      );
+
       config.variable.edit.codelist = {};
+
       config.variable.edit.address = {
         defaultMunicipality:
           userConfig.variable?.edit?.address?.defaultMunicipality,
@@ -462,6 +503,7 @@ export default class SimpleEditorComponent extends Component {
     nodeViews.table_of_contents = (controller) =>
       tableOfContentsView(config.tableOfContents)(controller);
   }
+
   setupTemplateCommentsPlugin(setup) {
     const { nodes, nodeViews } = setup;
     nodes.templateComment = templateComment;

--- a/app/config/defaults.js
+++ b/app/config/defaults.js
@@ -1,0 +1,87 @@
+import merge from 'lodash.mergewith';
+
+/**
+ * @type {import("@lblod/ember-rdfa-editor-lblod-plugins/plugins/rdfa-date-plugin/index").DateOptions}
+ */
+export const defaultRdfaDatePluginConfig = (t) => ({
+  placeholder: {
+    insertDate: t('date-plugin.insert.date'),
+    insertDateTime: t('date-plugin.insert.datetime'),
+  },
+  formats: [
+    {
+      label: 'Short Date',
+      key: 'short',
+      dateFormat: 'dd/MM/yy',
+      dateTimeFormat: 'dd/MM/yy HH:mm',
+    },
+    {
+      label: 'Long Date',
+      key: 'long',
+      dateFormat: 'EEEE dd MMMM yyyy',
+      dateTimeFormat: 'PPPPp',
+    },
+  ],
+  allowCustomFormat: true,
+});
+
+/**
+ * @type {import("@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin").CitationPluginEmberComponentConfig}
+ */
+export const defaultCitationPluginConfig = {
+  type: 'ranges',
+  activeInRanges: (state) => [[0, state.doc.content.size]],
+  endpoint: '/codex/sparql',
+};
+
+/**
+ * @type {import("@lblod/ember-rdfa-editor-lblod-plugins/plugins/roadsign-regulation-plugin").RoadsignRegulationPluginOptions}
+ */
+export const defaultRoadsignRegulationPluginConfig = {
+  endpoint: 'https://dev.roadsigns.lblod.info/sparql',
+  imageBaseUrl: 'https://register.mobiliteit.vlaanderen.be/',
+};
+
+/**
+ * @type {import("@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/location/edit").LocationEditOptions}
+ */
+export const defaultLocationVariablePluginConfig = {
+  endpoint: 'https://dev.roadsigns.lblod.info/sparql',
+  zonalLocationCodelistUri:
+    'http://lblod.data.gift/concept-schemes/62331E6900730AE7B99DF7EF',
+  nonZonalLocationCodelistUri:
+    'http://lblod.data.gift/concept-schemes/62331FDD00730AE7B99DF7F2',
+};
+
+/**
+ * @type {import("@lblod/ember-rdfa-editor-lblod-plugins/plugins/table-of-contents-plugin").TableOfContentsConfig}
+ */
+export const defaultTableOfContentsPluginConfig = [
+  {
+    nodeHierarchy: [
+      'title|chapter|section|subsection|article',
+      'structure_header|article_header',
+    ],
+  },
+];
+
+const mergeCustomizer = (objValue, srcValue) => {
+  if (Array.isArray(objValue) && Array.isArray(srcValue)) {
+    return srcValue;
+  }
+};
+
+/**
+ * If the user config is present, merge it with the default config.
+ * Otherwise return the default config.
+ * @param defaultConfig
+ * @param userConfig
+ * @returns {*}
+ */
+export const mergeConfigs = (defaultConfig, userConfig) => {
+  if (userConfig) {
+    return merge(defaultConfig, userConfig, mergeCustomizer);
+  }
+
+  return defaultConfig;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-qunit": "^8.0.0",
         "loader.js": "^4.7.0",
+        "lodash.merge": "^4.6.2",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.7.1",
         "qunit": "^2.17.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-qunit": "^8.0.0",
         "loader.js": "^4.7.0",
-        "lodash.merge": "^4.6.2",
+        "lodash.mergewith": "^4.6.2",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.7.1",
         "qunit": "^2.17.2",
@@ -27281,6 +27281,12 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "dev": true
     },
     "node_modules/lodash.omit": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "ember-intl": "^5.7.2",
     "ember-unique-id-helper-polyfill": "^1.2.2"
+
   },
   "devDependencies": {
     "@appuniversum/ember-appuniversum": "^2.4.0",
@@ -80,6 +81,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-qunit": "^8.0.0",
     "loader.js": "^4.7.0",
+    "lodash.merge": "^4.6.2",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.7.1",
     "qunit": "^2.17.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "ember-intl": "^5.7.2",
     "ember-unique-id-helper-polyfill": "^1.2.2"
-
   },
   "devDependencies": {
     "@appuniversum/ember-appuniversum": "^2.4.0",
@@ -81,7 +80,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-qunit": "^8.0.0",
     "loader.js": "^4.7.0",
-    "lodash.merge": "^4.6.2",
+    "lodash.mergewith": "^4.6.2",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.7.1",
     "qunit": "^2.17.2",


### PR DESCRIPTION
## Overview

* Use `lodash.merge` to merge user and default config
* User JSDoc `@type` hints for some extra visibility on whether the default config is correct

#### Connected issues and PRs:

* https://binnenland.atlassian.net/browse/GN-4510


### Setup
1. Checkout
2. `npm i`
3. `npm run start`
4. Make sure the editor works :D 

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations