### PR TITLE
GN-4526: use language based on user browser's locale and add locale helpers

### DIFF
--- a/.changeset/fair-bananas-exercise.md
+++ b/.changeset/fair-bananas-exercise.md
@@ -1,0 +1,10 @@
+---
+'frontend-embeddable-notule-editor': minor
+---
+
+- fix: localize language of the editor based on the user's browser local. The fallback in all cases is Dutch (nl-BE)
+- Add extra locale helper functions to give control over the editor's language to a consumer
+  - `setLocale` to set a general locale
+  - `getLocale` to get the current locale
+  - `setLocaleToDutch` to easily set the editor to Dutch
+  - `setLocaleToEnglish` to easily set the editor to English

--- a/README.md
+++ b/README.md
@@ -166,9 +166,10 @@ These are function available from the editor element, which is the HTML element 
 - `controller`: direct access the the [SayController](https://github.com/lblod/ember-rdfa-editor/blob/d4472d2e237256d30333cfcc20ce6eea7db241f2/addon/core/say-controller.ts) object. See [controller API](controller-api).
 - `setHtmlContent(content: string)`: set the HTML content inside the editor, overwriting all previous content.  
 - `getHtmlContent()`: Get the HTML content of the editor. This can be different than custom content set via `setHtmlContent`, because of HTML parsing logic.
-- `setLocalToDutch()`: Set the local (language used) of the editor to Dutch.
-- `setLocalToEnglish()`: Set the local (language used) of the editor to English.
-- `getLocal()`: returns the current local of the editor, being `nl-BE`, `en-US` or the user's browser locale. See more at [Localization](localization).
+- `setLocaleToDutch()`: Set the locale (language used) of the editor to Dutch.
+- `setLocaleToEnglish()`: Set the locale (language used) of the editor to English.
+- `getLocale()`: returns the current locale of the editor. This will be the user's browser locale, the set local with `setLocale`, or `nl-BE`/`en-US`, the supported languages. See more at [Localization](localization).
+- `setLocale(locale: string)`: set the current locale of the editor. Any locale is accepted, but will fallback to `nl-BE` if it is not `nl-BE` or `en-US` (the supported languages).
 
 #### controller API
 These methods are accessible via `editorElement.controller` and contain a way to directly interact with the Prosemirror logic underneath. This is an instance of [SayController](https://github.com/lblod/ember-rdfa-editor/blob/d4472d2e237256d30333cfcc20ce6eea7db241f2/addon/core/say-controller.ts). Not all possible methods are shown.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ The readme is structures as follows
 - [Editor API](editor-api): list of methods and properties to customize the editor and interact with it through code.
 - [Configuring The Editor](configuring-the-editor): ways to configure the editor during loading. The editor includes a list of plugins that can be enabled and configured as explained in [Managing Plugins](managing-plugins). 
 
-
 ## Live Demo
 A [live demo](https://embeddable.gelinkt-notuleren.lblod.info) is available for easy testing. 
 This environment is NOT suited for any production use, as it might change without notice and might be an outdated version. 
@@ -167,6 +166,9 @@ These are function available from the editor element, which is the HTML element 
 - `controller`: direct access the the [SayController](https://github.com/lblod/ember-rdfa-editor/blob/d4472d2e237256d30333cfcc20ce6eea7db241f2/addon/core/say-controller.ts) object. See [controller API](controller-api).
 - `setHtmlContent(content: string)`: set the HTML content inside the editor, overwriting all previous content.  
 - `getHtmlContent()`: Get the HTML content of the editor. This can be different than custom content set via `setHtmlContent`, because of HTML parsing logic.
+- `setLocalToDutch()`: Set the local (language used) of the editor to Dutch.
+- `setLocalToEnglish()`: Set the local (language used) of the editor to English.
+- `getLocal()`: returns the current local of the editor, being `nl-BE`, `en-US` or the user's browser locale. See more at [Localization](localization).
 
 #### controller API
 These methods are accessible via `editorElement.controller` and contain a way to directly interact with the Prosemirror logic underneath. This is an instance of [SayController](https://github.com/lblod/ember-rdfa-editor/blob/d4472d2e237256d30333cfcc20ce6eea7db241f2/addon/core/say-controller.ts). Not all possible methods are shown.
@@ -490,8 +492,11 @@ The environment banner is a visual indication of the environment you are current
 You can enable/disable the banner using the following methods: `enableEnvironmentBanner` and `disableEnvironmentBanner`.
 
 ## Localization
-Localization of the editor is an ongoing effort, the main target usage of Embeddable is currently Dutch speaking users. Some plugins, like the [citation plugin](https://github.com/lblod/ember-rdfa-editor-citaten-plugin/), use date pickers. The display format of these dates can be configured in the localization initializer.
+Localization of the editor is an ongoing effort, the main target usage of Embeddable is currently Dutch speaking users. The editor will use the user's browser language and supports English (en-US) and Dutch (nl-BE). If the user has a different language set, the editor will default to Dutch.
 
+Some plugins, like the [citation plugin](https://github.com/lblod/ember-rdfa-editor-citaten-plugin/), use date pickers. The display format of these dates are connected with the local.
+
+The local can be overwritten with `setLocalToDutch()` and `setLocalToEnglish()`. You can call one of these functions after `initEditor()` to always use the same language for the editor, ignoring the user's browser language.
 ## Styling
 Styling the editor is covered in the [README](https://github.com/lblod/ember-rdfa-editor#customisation) of ember-rdfa-editor. This frontend supports SASS, customizations can be added to [app.scss](app/styles/app.scss)
 

--- a/app/components/simple-editor.js
+++ b/app/components/simple-editor.js
@@ -138,9 +138,10 @@ export default class SimpleEditorComponent extends Component {
     this.editorElement.initEditor = this.initEditor;
     this.editorElement.enableEnvironmentBanner = this.enableEnvironmentBanner;
     this.editorElement.disableEnvironmentBanner = this.disableEnvironmentBanner;
-    this.editorElement.setLocalToDutch = this.setLocalToDutch;
-    this.editorElement.setLocalToEnglish = this.setLocalToEnglish;
-    this.editorElement.getLocal = this.getLocal;
+    this.editorElement.setLocaleToDutch = this.setLocaleToDutch;
+    this.editorElement.setLocaleToEnglish = this.setLocaleToEnglish;
+    this.editorElement.getLocale = this.getLocale;
+    this.editorElement.setLocale = this.setLocale;
   }
 
   /**
@@ -168,18 +169,23 @@ export default class SimpleEditorComponent extends Component {
   }
 
   @action
-  setLocalToDutch() {
+  setLocaleToDutch() {
     this.intl.setLocale(['nl-BE']);
   }
 
   @action
-  setLocalToEnglish() {
+  setLocaleToEnglish() {
     this.intl.setLocale(['en-US', 'nl-BE']);
   }
 
   @action
-  getLocal() {
+  getLocale() {
     return this.intl.primaryLocale;
+  }
+
+  @action
+  setLocale(locale) {
+    return this.intl.setLocale([locale, 'nl-BE']);
   }
 
   @action

--- a/app/components/simple-editor.js
+++ b/app/components/simple-editor.js
@@ -138,6 +138,9 @@ export default class SimpleEditorComponent extends Component {
     this.editorElement.initEditor = this.initEditor;
     this.editorElement.enableEnvironmentBanner = this.enableEnvironmentBanner;
     this.editorElement.disableEnvironmentBanner = this.disableEnvironmentBanner;
+    this.editorElement.setLocalToDutch = this.setLocalToDutch;
+    this.editorElement.setLocalToEnglish = this.setLocalToEnglish;
+    this.editorElement.getLocal = this.getLocal;
   }
 
   /**
@@ -162,6 +165,21 @@ export default class SimpleEditorComponent extends Component {
   @action
   setHtmlContent(content) {
     this.controller.setHtmlContent(content);
+  }
+
+  @action
+  setLocalToDutch() {
+    this.intl.setLocale(['nl-BE']);
+  }
+
+  @action
+  setLocalToEnglish() {
+    this.intl.setLocale(['en-US', 'nl-BE']);
+  }
+
+  @action
+  getLocal() {
+    return this.intl.primaryLocale;
   }
 
   @action

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
 import EmberObject from '@ember/object';
+import { inject as service } from '@ember/service';
 
 const defaultContext = {
   vocab: 'http://data.vlaanderen.be/ns/besluit#',
@@ -20,11 +21,17 @@ const defaultContext = {
 };
 
 export default class ApplicationRoute extends Route {
+  @service intl;
   model() {
     return EmberObject.create({
       title: 'new document',
       content: '',
       context: defaultContext,
     });
+  }
+  beforeModel(transition) {
+    const userLocale = navigator.language || navigator.languages[0];
+    this.intl.setLocale([userLocale, 'nl-BE']);
+    return super.beforeModel(transition);
   }
 }

--- a/public/test.html
+++ b/public/test.html
@@ -48,7 +48,7 @@
             autoboot: false,
             name: 'frontend-embeddable-notule-editor',
           });
-        // Lanuch the editor
+        // Launch the editor
         let editor;
         App.visit('/', { rootElement: '#my-editor' }).then(() => {
           const editorContainer = document.getElementById('my-editor');


### PR DESCRIPTION
## Overview
- The localization did not work, everything always displayed in English. This is fixed.
- Consumers might not care about localization and just want to have every user see the same (probably Dutch :) ) UI. For this, some functions were added.


##### connected issues and PRs:
- fixes https://binnenland.atlassian.net/browse/GN-4526

### How to test/reproduce
- see that changing browser language switches up the language of UI.
- see that using `setLocalTo...` after initEditor changes the language, no matter what your browser locale is.
- see that running `setLocalTo...` inside the browser's console switches up the language (see under "developer" "How it works" in the readme for how to do this).

### Challenges/uncertainties
- I kept the API for changing local simple to avoid keeping it complicated. It gives all the tools to create a locale switch button or to make sure the local follows that of the main app that uses the editor.
- I removed "The display format of these dates can be configured in the localization initializer.", because I had no idea what this actually meant. As far as I can see, it just follows the local as used by other plugins.
- some things aren't translated correctly yet, like the dropdown of the variables. Depending on when this gets reviewed I'll fix that here or in another PR :shrug: 


