### PR TITLE
Allow use of variable plugin without date plugin

### DIFF
--- a/.changeset/silent-elephants-accept.md
+++ b/.changeset/silent-elephants-accept.md
@@ -1,0 +1,6 @@
+---
+'frontend-embeddable-notule-editor': minor
+---
+
+The variable plugin does not need the RDFa date plugin to be active anymore.
+It will activate what it needs itself. Configurations stay the same.

--- a/README.md
+++ b/README.md
@@ -414,8 +414,6 @@ tableOfContents: [
 **note**: this config is a *list*. Multiple `nodeHierarchy`s can be passed to let the table of contents work in multiple situation. The last matching hierarchy will be used.
 
 ### RDFa Variables
-> :warning: [RDFa date plugin](rdfa-date) is required to be added when using this plugin.
-
 These are placeholders that can be inserted in a document. A variable placeholder has a specific type (text, number, date, address or codelist), which changes the type of input it can receive. These placeholders can then be filled in by a user using the document.
 
 Usually variables are inserted in an editor made to create *templates* (documents to be filled in), and only edited in an editor to fill in these *templates*. Via the config you can customize if you want to allow insertion and/or filling in a variable.
@@ -436,6 +434,9 @@ A variable can be inserted with the card shown in the right sidebar.
 :heavy_plus_sign: Enable by adding `"variable"` to the `arrayOfPluginNames` array.
 ```javascript
 // pass to pluginsConfig
+date: {
+  // see RDFa Date plugin for config
+},
 variable: {
   insert: {
       enable: true,
@@ -455,17 +456,19 @@ variable: {
     }
 },
 ```
-- `insert`: configuration for inserting a variable
-	- `enable`: is inserting a variable allowed (removing is always possible!)
-	- `codelistEndpoint`: the endpoint from which to fetch the codelists, which will be added to a codelist variable's RDFa. For production you'll likely want to use https://register.mobiliteit.vlaanderen.be/sparql`.
-	- `codelistPublisher`: Limit the codelists to a specific publisher. *null* will allow all codelists.
-	- `locationEndpoint`: the endpoint to fetch location options, which will be added to the location variable's RDFa and used as the endpoint when selecting a location variable. For production you'll likely want to use `https://register.mobiliteit.vlaanderen.be`.
-- `edit`: configuration for editing an inserted variable
-	- `enable`: is editing a variable allowed (removing is always possible!)
-	- `location`: config for location variable
-		- `endpoint`: *fallback* endpoint for location variable if the variable is missing the endpoint in its RDFa. This will most likely be the same as the endpoint used for inserting.
-		- `zonalLocationCodelistUri`: the URI to search for if the location variable is included in a zonal traffic measure.
-		- `nonZonalLocationCodelistUri`: the URI to search for if the location variable is included in a non-zonal traffic measure.
+- `date`: configuration for the date variable, see [RDFa Date plugin](#rdfa-date) how to configure.
+- `variable`: configuration for all variables
+  - `insert`: configuration for inserting a variable
+  	- `enable`: is inserting a variable allowed (removing is always possible!)
+  	- `codelistEndpoint`: the endpoint from which to fetch the codelists, which will be added to a codelist variable's RDFa. For production you'll likely want to use https://register.mobiliteit.vlaanderen.be/sparql`.
+  	- `codelistPublisher`: Limit the codelists to a specific publisher. *null* will allow all codelists.
+  	- `locationEndpoint`: the endpoint to fetch location options, which will be added to the location variable's RDFa and used as the endpoint when selecting a location variable. For production you'll likely want to use `https://register.mobiliteit.vlaanderen.be`.
+  - `edit`: configuration for editing an inserted variable
+  	- `enable`: is editing a variable allowed (removing is always possible!)
+  	- `location`: config for location variable
+  		- `endpoint`: *fallback* endpoint for location variable if the variable is missing the endpoint in its RDFa. This will most likely be the same as the endpoint used for inserting.
+  		- `zonalLocationCodelistUri`: the URI to search for if the location variable is included in a zonal traffic measure.
+  		- `nonZonalLocationCodelistUri`: the URI to search for if the location variable is included in a non-zonal traffic measure.
 
 ### Formatting Toggle
 This will add a button in the top toolbar `Show formatting marks`. This toggles the visibility of all formatting marks of the document such as break lines, paragraphs...

--- a/app/components/simple-editor.hbs
+++ b/app/components/simple-editor.hbs
@@ -142,7 +142,7 @@
                 @options={{this.config.structures}}
               />
             {{/if}}
-            {{#if (array-includes this.activePlugins 'rdfa-date')}}
+            {{#if (array-includes this.activePlugins 'rdfa-date' 'variable')}}
                 <RdfaDatePlugin::Card
                   @controller={{this.controller}}
                   @options={{this.config.date}}

--- a/app/components/simple-editor.js
+++ b/app/components/simple-editor.js
@@ -271,7 +271,10 @@ export default class SimpleEditorComponent extends Component {
     ];
     const nodeViews = {};
     const setup = { nodes, marks, plugins, nodeViews, userConfig, config };
-    if (activePlugins.includes('rdfa-date')) {
+    if (
+      activePlugins.includes('rdfa-date') ||
+      activePlugins.includes('variable')
+    ) {
       this.setupDatePlugin(setup);
     }
     if (activePlugins.includes('citation')) {

--- a/app/helpers/array-includes.js
+++ b/app/helpers/array-includes.js
@@ -1,5 +1,7 @@
 import { helper } from '@ember/component/helper';
 
-export default helper(function arrayIncludes([array, value] /*, named*/) {
-  return array.includes(value);
+export default helper(function arrayIncludes(arrayAndValues /*, named*/) {
+  let array = arrayAndValues[0];
+  let values = arrayAndValues.slice(1, arrayAndValues.length);
+  return values.some((v) => array.includes(v));
 });

--- a/public/test.html
+++ b/public/test.html
@@ -54,7 +54,7 @@
           const editorContainer = document.getElementById('my-editor');
           const editorElement =
           editorContainer.getElementsByClassName('notule-editor')[0];
-          editorElement.initEditor(['citation', 'besluit', 'article-structure', 'variable', 'table-of-contents',
+          editorElement.initEditor(['citation', 'besluit','rdfa-date', 'article-structure', 'variable', 'table-of-contents',
                                          'roadsign-regulation', 'formatting-toggle', 'template-comments'], {
                                           docContent: 'table_of_contents? ((chapter|block)+|(title|block)+|(article|block)+)',
                                           citation: {

--- a/public/test.html
+++ b/public/test.html
@@ -54,7 +54,7 @@
           const editorContainer = document.getElementById('my-editor');
           const editorElement =
           editorContainer.getElementsByClassName('notule-editor')[0];
-          editorElement.initEditor(['citation', 'besluit','rdfa-date', 'article-structure', 'variable', 'table-of-contents',
+          editorElement.initEditor(['citation', 'besluit', 'article-structure', 'variable', 'table-of-contents',
                                          'roadsign-regulation', 'formatting-toggle', 'template-comments'], {
                                           docContent: 'table_of_contents? ((chapter|block)+|(title|block)+|(article|block)+)',
                                           citation: {


### PR DESCRIPTION
## Overview
Before a warning had to be added to also include the date plugin when using the variable plugin. This removes this necessity, decreasing the complexity of Embeddable.

### How to test/reproduce
remove `rdfa-date` from the plugins list in test.html example, see that the variable plugin, especially the date variable, works as expected. The config for a date should also still have an influence (try to add another format to test this out :) )

### Challenges/uncertainties
Really, it is a bit confusing that the date variable is a separate plugin.
In principle it would be better to have one variable plugin, give the option for every variable to be included in the insert menu and/or the variable dropdown (explaining that the dropdown allows adding a label), and remove rdfa date variable.

But that's more work, and this already removes one of the warnings from the readme, which we want to avoid as much as possible :)