### PR TITLE
Internationalize remaining hard-coded parts of `simple-editor` component

### DIFF
--- a/.changeset/long-garlics-deny.md
+++ b/.changeset/long-garlics-deny.md
@@ -1,0 +1,5 @@
+---
+'frontend-embeddable-notule-editor': patch
+---
+
+Internationalize sidebar insert-button

--- a/.changeset/ten-zebras-deny.md
+++ b/.changeset/ten-zebras-deny.md
@@ -1,0 +1,5 @@
+---
+'frontend-embeddable-notule-editor': patch
+---
+
+Internationalize insert-variable dropdown

--- a/app/components/simple-editor.hbs
+++ b/app/components/simple-editor.hbs
@@ -103,7 +103,7 @@
       <:aside>
         {{#if this.controller}}
           <Sidebar as |Sidebar|>
-            <Sidebar.Collapsible @title='Insert'>
+            <Sidebar.Collapsible @title={{t "editor.insert"}}>
               {{#if (array-includes this.activePlugins 'article-structure')}}
                 <ArticleStructurePlugin::ArticleStructureCard
                   @controller={{this.controller}}

--- a/app/components/simple-editor.js
+++ b/app/components/simple-editor.js
@@ -381,19 +381,19 @@ export default class SimpleEditorComponent extends Component {
     if (config.variable.insert.enable) {
       config.variable.insert.variableTypes = [
         {
-          label: 'text',
+          label: this.intl.t('editor.variables.text'),
           component: {
             path: 'variable-plugin/text/insert',
           },
         },
         {
-          label: 'number',
+          label: this.intl.t('editor.variables.number'),
           component: {
             path: 'variable-plugin/number/insert',
           },
         },
         {
-          label: 'location',
+          label: this.intl.t('editor.variables.location'),
           component: {
             path: 'variable-plugin/location/insert',
             options: {
@@ -404,19 +404,19 @@ export default class SimpleEditorComponent extends Component {
           },
         },
         {
-          label: 'address',
+          label: this.intl.t('editor.variables.address'),
           component: {
             path: 'variable-plugin/address/insert',
           },
         },
         {
-          label: 'date',
+          label: this.intl.t('editor.variables.date'),
           component: {
             path: 'variable-plugin/date/insert',
           },
         },
         {
-          label: 'codelist',
+          label: this.intl.t('editor.variables.codelist'),
           component: {
             path: 'variable-plugin/codelist/insert',
             options: {

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -1,0 +1,9 @@
+editor:
+  variables:
+    text: text
+    number: number
+    address: address
+    location: location
+    date: date
+    codelist: codelist
+  insert: Insert

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -1,0 +1,9 @@
+editor:
+  variables:
+    text: tekst
+    number: nummer
+    address: adres
+    location: locatie
+    date: datum
+    codelist: codelijst
+  insert: Invoegen


### PR DESCRIPTION
## Overview
This PR adds internationalization for the remaining hard-coded parts of the editor:
- the `insert` button in the editor sidebar
- the variable-insert dropdown

### How to test/reproduce
- `npm start`
- Ensure that the `insert` button and variable-insert dropdown are properly internationalized based on the configured locale.



### Checks PR readiness
- [x] changelog
- [x] npm lint
- [x] no new deprecations