### PR TITLE
Remove modes from article structure + add explanation how to enable TOC correctly via docContent

### DIFF
--- a/.changeset/quiet-falcons-pump.md
+++ b/.changeset/quiet-falcons-pump.md
@@ -1,5 +1,0 @@
----
-'frontend-embeddable-notule-editor': minor
----
-
-When activating TOC plugin, `table_of_contents` will automatically be added to the docContent. This node is mandatory in docContent to make TOC work.

--- a/.changeset/quiet-falcons-pump.md
+++ b/.changeset/quiet-falcons-pump.md
@@ -1,0 +1,5 @@
+---
+'frontend-embeddable-notule-editor': minor
+---
+
+When activating TOC plugin, `table_of_contents` will automatically be added to the docContent. This node is mandatory in docContent to make TOC work.

--- a/.changeset/two-seahorses-double.md
+++ b/.changeset/two-seahorses-double.md
@@ -1,0 +1,17 @@
+---
+'frontend-embeddable-notule-editor': major
+---
+
+Changes the workings of the `besluit` and `article-structure` plugins
+
+- the modes for `article-structure` are gone.
+- `besluit` and `article-structure` can be used together
+- no more configuration needed for either plugins
+- some more documentation about using `article-structure` effectively
+
+Now the besluit plugin adds besluit nodes and adds the insert buttons for these node(s) (before it only added the structure)
+Now the article structure plugin adds article structure nodes and insert buttons (like before) and is not connected at all anymore with besluit nodes (before insert buttons for besluit nodes were added via article structure plugin)
+
+To migrate:
+- What was `article-structure` in `regulatoryStatement` mode before is now just the `article-structure` plugin, without specifying a mode.
+- What was `article-structure` in `besluit` mode before is now just the `besluit` plugin, without specifying a mode. 

--- a/README.md
+++ b/README.md
@@ -395,10 +395,12 @@ tableOfContents: [
     ],
   },
 ],
-```
+docContent: 'block',
+``` 
 - `nodeHierarchy`: a list of regex strings to specify the node structure. The default value works for the [article-structure plugin](#article-structure). 
   The first string are the main nodes that should be added to the structure.
   The strings afterwards are the sub-nodes of the main node that should be used to find the actual content to display in the table of contents.
+- `docContent`: defined in [general config options](general-config-options). When enabling this plugin, the string `table_of_contents?` will automatically be appended to `docContent` at the start if it is not part of the `docContent` yet. This is needed as `table_of_contents` is not in the `block` group. You can override this behavior by adding `table_of_contents?` to the desired place in `docContent` instead. 
 
 **note**: this config is a *list*. Multiple `nodeHierarchy`s can be passed to let the table of contents work in multiple situation. The last matching hierarchy will be used.
 

--- a/README.md
+++ b/README.md
@@ -395,12 +395,10 @@ tableOfContents: [
     ],
   },
 ],
-docContent: 'block',
-``` 
+```
 - `nodeHierarchy`: a list of regex strings to specify the node structure. The default value works for the [article-structure plugin](#article-structure). 
   The first string are the main nodes that should be added to the structure.
   The strings afterwards are the sub-nodes of the main node that should be used to find the actual content to display in the table of contents.
-- `docContent`: defined in [general config options](general-config-options). When enabling this plugin, the string `table_of_contents?` will automatically be appended to `docContent` at the start if it is not part of the `docContent` yet. This is needed as `table_of_contents` is not in the `block` group. You can override this behavior by adding `table_of_contents?` to the desired place in `docContent` instead. 
 
 **note**: this config is a *list*. Multiple `nodeHierarchy`s can be passed to let the table of contents work in multiple situation. The last matching hierarchy will be used.
 

--- a/README.md
+++ b/README.md
@@ -203,8 +203,8 @@ This Readme contains all the important info and configuration for the plugins. F
 Every plugin can be enabled by passing its name to the `arrayOfPluginNames` array and optionally its configuration to `userConfigObject` with the initialization function `initEditor(arrayOfPluginNames, userConfigObject)`.  
 Any configuration value not provided will use the default value, which are shown in the example configs of the plugins.
 
-* [article-structure](#article-structure): Provides structures to better manage official documents, like titles, chapters, articles and paragraphs. It allows you to insert, move and delete them. It has two modes: `besluit` for besluit articles and `regulatoryStatement` for all other structures.
-* [besluit](#besluit): Provides the correct rdfa-structure for constructing a decision (besluit).
+* [article-structure](#article-structure): Provides structures like titles, chapters, articles and paragraphs, which can be used to better manage official documents like regulatory statements. It allows you to insert, move and delete them.
+* [besluit](#besluit): Provides the correct rdfa-structure for constructing a decision (besluit) with ways to move and delete them.
 * [citation](#citation): Search and insert references to citations (a legal resource/expression)
 * [rdfa-date](#rdfa-date): Inserting and modifying annotated dates and times
 * [roadsign-regulation](#roadsign-regulation): Insert roadsign regulations, based on the registry managed and provided by MOW (Mobiliteit en Openbare Werken)
@@ -215,41 +215,31 @@ Any configuration value not provided will use the default value, which are shown
 * [template-comments](#template-comments): Allows insertion and editing of comment blocks to provide extra information to a user filling in a document. These are visually distinct units with a special RDFa type, which allows them to be filtered out during postprocessing.
 ##### General Config options
 There are some options you can pass to `pluginsConfig` in `initEditor` that are not connected to a plugin.
-- `docContent: 'block+'`: The property docContent specifies which nodes are allowed in the document. By default we allow one or more nodes of the supertype block, which includes most content. For more info about this check the [Prosemirror docs](https://prosemirror.net/docs/guide/#schema.content_expressions).  
+- `docContent: 'block+'`: The property docContent specifies which nodes are allowed in the document. By default we allow one or more nodes of the group block, which includes most content. A group can be seen as a supertype that includes multiple types. For more info about this check the [Prosemirror docs](https://prosemirror.net/docs/guide/#schema.content_expressions).  
   See `public/test.html` where `docContent` is specified to allow [article-structure](#article-structure) nodes in a specific order.
 
 ### Article Structure
-This plugin is in charge of inserting and manipulating structures. There are insertion buttons in the insert menu of the right sidebar. The plugin has two modes, being `besluit` and `regulatoryStatement`. 
+This plugin is in charge of inserting and manipulating structures. There are several insertion buttons in the insert menu of the right sidebar under "Document Structuren".
 
-- `besluit` Mode
-	- Only allowed to insert articles
-- `regulatoryStatement` mode
-	- Able to insert titles, chapters, sections... 
-	- [table-of-contents](#Table of Contents) default config works with this mode.
+After inserting a structure and selecting it, a card will show options to move and delete the structure. These might be disabled if the action is not possible. Using the button "with content" will also delete everything included in the structure, instead of just the closest heading. 
 
-After inserting a structure and selecting it, a card will show options to move and delete the structure. These might be disabled if the action is not possible. 
+Anything part of the `block` group (almost everything) is allowed under these structures. However, the article structure nodes themselves are only allowed in a specific order.
 
-Using the button "with content" will also delete everything included in the structure, instead of just the closest heading. 
 ![article structure card](https://imgur.com/2zkbNw3.png)
 ***
 :heavy_plus_sign: Enable by adding `"article-structure"` to the `arrayOfPluginNames` array.
 
-```javascript
-// pass to pluginsConfig
-articleStructure: {
-  mode: 'besluit',
-}
+These structures are not part of the `block` group. You will need to edit `docContent` to accept one of these structures as a base. The following config will allow a title, chapter or article to be added as the first node, or any general block. See [general config options](general-config-options) for more info.
 ```
-The options for mode are:
-- 'besluit' (default): for manipulating articles in decisions. 
-- 'regulatoryStatement': for manipulating chapters, sections, etc as regulatory statements.
-
+// pass to pluginsConfig
+docContent: '((title|block)+|(chapter|block)+|(article|block)+)'
+```
 ### Besluit 
- :warning: The besluit plugin is incompatible with the `regulatoryStatement` mode of  [article-structure](#Article Structure).
-
-This will add rdfa structures to create a besluit.
+This will add RDFa structures to create a besluit.  
+A besluit is a specific document in a specific format. This means that using it together with [Article Structures](article-structure) might not make sense.
 ***
 :heavy_plus_sign: Enable by adding `"besluit"` to the `arrayOfPluginNames` array.
+
 No configuration is needed.
 
 ### Citation
@@ -390,7 +380,7 @@ roadsignRegulation: {
 ### Table of Contents
 Add a table of contents at the top of the document. It can be toggled with a button in the top toolbar. 
 
-At this time it will only work well together with [article-structure plugin](#article-structure) in `regulatoryStatement` mode by using the default config.
+At this time it will only work well together with [article-structure plugin](#article-structure) by using the default config.
 
 :warning: For use in different situations, open an issue on this repo with the usecase, so we can help. The [Prosemirror schema](https://prosemirror.net/docs/guide/#schema) that is used in the config is public-facing yet, so changing this is not trivial.
 ***

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Any configuration value not provided will use the default value, which are shown
 ##### General Config options
 There are some options you can pass to `pluginsConfig` in `initEditor` that are not connected to a plugin.
 - `docContent: 'block+'`: The property docContent specifies which nodes are allowed in the document. By default we allow one or more nodes of the group block, which includes most content. A group can be seen as a supertype that includes multiple types. For more info about this check the [Prosemirror docs](https://prosemirror.net/docs/guide/#schema.content_expressions).  
-  See `public/test.html` where `docContent` is specified to allow [article-structure](#article-structure) nodes in a specific order.
+  See `public/test.html` where `docContent` is specified to allow a [table of contents](#table-of-contents) and [article-structure](#article-structure) nodes in a specific order.
 
 ### Article Structure
 This plugin is in charge of inserting and manipulating structures. There are several insertion buttons in the insert menu of the right sidebar under "Document Structuren".
@@ -387,6 +387,7 @@ At this time it will only work well together with [article-structure plugin](#ar
 :heavy_plus_sign: Enable by adding `"table-of-contents"` to the `arrayOfPluginNames` array.
 ```javascript
 // pass to pluginsConfig
+docContent: /*adjust to include `table_of_contents?` as an accepted node*/ ,
 tableOfContents: [
   {
     nodeHierarchy: [
@@ -399,6 +400,7 @@ tableOfContents: [
 - `nodeHierarchy`: a list of regex strings to specify the node structure. The default value works for the [article-structure plugin](#article-structure). 
   The first string are the main nodes that should be added to the structure.
   The strings afterwards are the sub-nodes of the main node that should be used to find the actual content to display in the table of contents.
+- `docContent`: You will need to adjust `docContent` to accept `table_of_contents?`, as it is not part of the `block` group. See [general config options](general-config-options) for more info.
 
 **note**: this config is a *list*. Multiple `nodeHierarchy`s can be passed to let the table of contents work in multiple situation. The last matching hierarchy will be used.
 

--- a/app/components/simple-editor.hbs
+++ b/app/components/simple-editor.hbs
@@ -104,12 +104,21 @@
         {{#if this.controller}}
           <Sidebar as |Sidebar|>
             <Sidebar.Collapsible @title={{t "editor.insert"}}>
-              {{#if (array-includes this.activePlugins 'article-structure')}}
+              {{#if (array-includes this.activePlugins 'besluit')}}
+                <div class="au-u-medium">{{t 'editor.besluit.title'}}</div>
                 <ArticleStructurePlugin::ArticleStructureCard
                   @controller={{this.controller}}
-                  @options={{this.config.structures}}
+                  @options={{this.config.besluit.structures}}
                 />
               {{/if}}
+              {{#if (array-includes this.activePlugins 'article-structure')}}
+                <div class="au-u-medium">{{t 'editor.article-structure.title'}}</div>
+                <ArticleStructurePlugin::ArticleStructureCard
+                  @controller={{this.controller}}
+                  @options={{this.config.articleStructure.structures}}
+                />
+              {{/if}}
+              <div class="au-u-medium">{{t 'editor.others.title'}}</div>
               {{#if (array-includes this.activePlugins 'citation')}}
                 <CitationPlugin::CitationInsert
                   @controller={{this.controller}}
@@ -139,7 +148,13 @@
             {{#if (array-includes this.activePlugins 'article-structure')}}
               <ArticleStructurePlugin::StructureCard
                 @controller={{this.controller}}
-                @options={{this.config.structures}}
+                @options={{this.config.articleStructure.structures}}
+              />
+            {{/if}}
+            {{#if (array-includes this.activePlugins 'besluit')}}
+              <ArticleStructurePlugin::StructureCard
+                @controller={{this.controller}}
+                @options={{this.config.besluit.structures}}
               />
             {{/if}}
             {{#if (array-includes this.activePlugins 'rdfa-date' 'variable')}}

--- a/app/components/simple-editor.js
+++ b/app/components/simple-editor.js
@@ -70,7 +70,7 @@ import {
 
 import {
   besluitNodes,
-  structureSpecs,
+  structureSpecs as besluitStructure,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/standard-template-plugin';
 
 import { citationPlugin } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin';
@@ -281,7 +281,7 @@ export default class SimpleEditorComponent extends Component {
       this.setupCitationPlugin(setup);
     }
     if (activePlugins.includes('article-structure')) {
-      this.setupStructurePlugin(setup);
+      this.setupArticleStructurePlugin(setup);
     }
     if (activePlugins.includes('besluit')) {
       this.setupBesluitPlugin(setup);
@@ -336,20 +336,17 @@ export default class SimpleEditorComponent extends Component {
     plugins.push(citationPluginVariable);
   }
 
-  setupStructurePlugin(setup) {
-    const { userConfig, config, nodes } = setup;
-    if (
-      userConfig.articleStructure &&
-      userConfig.articleStructure.mode === 'regulatoryStatement'
-    ) {
-      config.structures = STRUCTURE_SPECS;
-    } else {
-      config.structures = structureSpecs;
-    }
-    setup.nodes = { ...nodes, ...STRUCTURE_NODES };
+  setupArticleStructurePlugin(setup) {
+    const { config } = setup;
+    config.articleStructure = {};
+    config.articleStructure.structures = STRUCTURE_SPECS;
+    setup.nodes = { ...setup.nodes, ...STRUCTURE_NODES };
   }
 
   setupBesluitPlugin(setup) {
+    const { config } = setup;
+    config.besluit = {};
+    config.besluit.structures = besluitStructure;
     setup.nodes = { ...setup.nodes, ...besluitNodes };
   }
 

--- a/app/components/simple-editor.js
+++ b/app/components/simple-editor.js
@@ -225,11 +225,9 @@ export default class SimpleEditorComponent extends Component {
       link: {
         interactive: true,
       },
+      docContent: userConfig.docContent ?? 'block+',
     };
     let nodes = {
-      doc: docWithConfig({
-        content: userConfig.docContent ?? 'block+',
-      }),
       paragraph,
       repaired_block,
       list_item,
@@ -298,8 +296,15 @@ export default class SimpleEditorComponent extends Component {
     if (activePlugins.includes('template-comments')) {
       this.setupTemplateCommentsPlugin(setup);
     }
+
     this.config = setup.config;
-    setup.nodes = { ...setup.nodes, heading, invisible_rdfa, block_rdfa };
+    setup.nodes = {
+      ...setup.nodes,
+      doc: docWithConfig({ content: config.docContent }),
+      heading,
+      invisible_rdfa,
+      block_rdfa,
+    };
     this.schema = new Schema({ nodes: setup.nodes, marks: setup.marks });
     this.plugins = setup.plugins;
     this.nodeViews = (controller) => {
@@ -455,6 +460,10 @@ export default class SimpleEditorComponent extends Component {
       defaultTableOfContentsPluginConfig,
       userConfig.tableOfContents
     );
+
+    if (!config.docContent.includes('table_of_contents')) {
+      config.docContent = 'table_of_contents? ' + config.docContent;
+    }
 
     nodes.table_of_contents = table_of_contents(config.tableOfContents);
 

--- a/app/components/simple-editor.js
+++ b/app/components/simple-editor.js
@@ -225,9 +225,11 @@ export default class SimpleEditorComponent extends Component {
       link: {
         interactive: true,
       },
-      docContent: userConfig.docContent ?? 'block+',
     };
     let nodes = {
+      doc: docWithConfig({
+        content: userConfig.docContent ?? 'block+',
+      }),
       paragraph,
       repaired_block,
       list_item,
@@ -296,15 +298,8 @@ export default class SimpleEditorComponent extends Component {
     if (activePlugins.includes('template-comments')) {
       this.setupTemplateCommentsPlugin(setup);
     }
-
     this.config = setup.config;
-    setup.nodes = {
-      ...setup.nodes,
-      doc: docWithConfig({ content: config.docContent }),
-      heading,
-      invisible_rdfa,
-      block_rdfa,
-    };
+    setup.nodes = { ...setup.nodes, heading, invisible_rdfa, block_rdfa };
     this.schema = new Schema({ nodes: setup.nodes, marks: setup.marks });
     this.plugins = setup.plugins;
     this.nodeViews = (controller) => {
@@ -460,10 +455,6 @@ export default class SimpleEditorComponent extends Component {
       defaultTableOfContentsPluginConfig,
       userConfig.tableOfContents
     );
-
-    if (!config.docContent.includes('table_of_contents')) {
-      config.docContent = 'table_of_contents? ' + config.docContent;
-    }
 
     nodes.table_of_contents = table_of_contents(config.tableOfContents);
 

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -7,3 +7,9 @@ editor:
     date: date
     codelist: codelist
   insert: Insert
+  besluit:
+    title: Decision
+  article-structure:
+    title: Document Structures
+  others:
+    title: General

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -7,3 +7,9 @@ editor:
     date: datum
     codelist: codelijst
   insert: Invoegen
+  besluit:
+    title: Besluit
+  article-structure:
+    title: Document Structuren
+  others:
+    title: Algemeen


### PR DESCRIPTION
## Overview
- remove the idea of "modes" and just support both besluit and article structures together
- move besluit and article structures to their own plugins (instead of a weird mix), where every plugin adds and shows everything that is needed for itself.
- some updated documentation. Biggest improvement is specifying how to even activate article-structures, as they are not blocks, so will not work with the default docContent config.
- ~~a small fix that adds `table_of_contents` to the docContent of the TOC plugin is activated. This is mandatory to make the TOC plugin work, and this makes the configuration easier for consumers.~~ => instead only the readme is updated to specify that `table_of_contents` has to be added.

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4514

### How to test/reproduce
- ~~try to remove `table_of_contents` from the test.html file docContent configuration~~
- try to use both besluit and article structure nodes together, try to remove one (or both) of them from the pluginsArray (in test.html) and see if stuff works like it should. 

### Challenges/uncertainties
- currently for besluit nodes only an article can be inserted. Having the header "besluit" with just one button is a bit ugly, but at least it is clear :shrug: 
- the header "General" will show up even if no buttons are there (e.g. no activated plugins). However the same problem happens for the general insert button: it will also show up even if there are no plugins active. Might be something for another PR.