### PR TITLE
GN-4543: Fix/enable `dependency-lint`

### DIFF
--- a/.changeset/funny-pots-sell.md
+++ b/.changeset/funny-pots-sell.md
@@ -1,0 +1,5 @@
+---
+'frontend-embeddable-notule-editor': patch
+---
+
+GN-4543: Enable `dependency-lint` on CI

--- a/.changeset/tender-countries-unite.md
+++ b/.changeset/tender-countries-unite.md
@@ -1,0 +1,8 @@
+---
+'frontend-embeddable-notule-editor': minor
+---
+
+GN-4543: Fix issues reported by `dependency-lint`
+
+* Pin `tracked-toolbox` to `^2.0.0` based on this comment - https://github.com/appuniversum/ember-appuniversum/pull/421#issuecomment-1706553230
+* Pin `ember-focus-trap` to `1.0.1` based on this issue - https://github.com/josemarluedke/ember-focus-trap/issues/82

--- a/.woodpecker/.verify-pr.yml
+++ b/.woodpecker/.verify-pr.yml
@@ -13,6 +13,11 @@ steps:
     group: lint
     commands:
       - npm run lint:hbs
+  dependency-lint:
+    image: danlynn/ember-cli:3.28.5
+    group: lint
+    commands:
+      - ember dependency-lint
   test:
     image: danlynn/ember-cli:3.28.5
     commands:

--- a/package-lock.json
+++ b/package-lock.json
@@ -148,22 +148,6 @@
         "ember-source": "^3.28.0 || ^4.0.0 || ^5.0.0"
       }
     },
-    "node_modules/@appuniversum/ember-appuniversum/node_modules/ember-focus-trap": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ember-focus-trap/-/ember-focus-trap-1.1.0.tgz",
-      "integrity": "sha512-KxbCKpAJaBVZm+bW4tHPoBJAZThmxa6pI+WQusL+bj0RtAnGUNkWsVy6UBMZ5QqTQzf4EvGHkCVACVp5lbAWMQ==",
-      "dev": true,
-      "dependencies": {
-        "@embroider/addon-shim": "^1.0.0",
-        "focus-trap": "^6.7.1"
-      },
-      "engines": {
-        "node": "12.* || >= 14"
-      },
-      "peerDependencies": {
-        "ember-source": "^4.0.0 || ^5.0.0"
-      }
-    },
     "node_modules/@babel/code-frame": {
       "version": "7.22.13",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
@@ -4766,27 +4750,6 @@
         "ieee754": "^1.2.1"
       }
     },
-    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/tracked-toolbox": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tracked-toolbox/-/tracked-toolbox-2.0.0.tgz",
-      "integrity": "sha512-adZtX+RGN6F+pWs/5JqVuDxLhuia4uhqmQp+UlUaxpykWjDFETtAdQR+LdDJiFPXFAXnS6FBqn/tnSLJQCm3Yw==",
-      "dev": true,
-      "dependencies": {
-        "@embroider/addon-shim": "^1.6.0",
-        "ember-cache-primitive-polyfill": "^1.0.0"
-      },
-      "engines": {
-        "node": "14.* || 16.* || >= 18"
-      },
-      "peerDependencies": {
-        "ember-source": "*"
-      },
-      "peerDependenciesMeta": {
-        "ember-source": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@lblod/ember-rdfa-editor/node_modules/ember-cli-typescript": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
@@ -8022,6 +7985,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
@@ -22550,6 +22514,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
       "optional": true
     },
     "node_modules/filesize": {
@@ -27689,6 +27654,7 @@
       "version": "2.17.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
       "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
+      "dev": true,
       "optional": true
     },
     "node_modules/nanoid": {
@@ -35657,16 +35623,24 @@
       }
     },
     "node_modules/tracked-toolbox": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/tracked-toolbox/-/tracked-toolbox-1.3.0.tgz",
-      "integrity": "sha512-KHfYLvNyRr0qQeXQPnmb6Z4JYZ0/47R7LjVwzUrsKc539eQi3Sz2z3mb7FJN9KgaJXVuM3GQ8zcwUFTf0hrOsQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tracked-toolbox/-/tracked-toolbox-2.0.0.tgz",
+      "integrity": "sha512-adZtX+RGN6F+pWs/5JqVuDxLhuia4uhqmQp+UlUaxpykWjDFETtAdQR+LdDJiFPXFAXnS6FBqn/tnSLJQCm3Yw==",
       "dev": true,
       "dependencies": {
-        "ember-cache-primitive-polyfill": "^1.0.0",
-        "ember-cli-babel": "^7.26.6"
+        "@embroider/addon-shim": "^1.6.0",
+        "ember-cache-primitive-polyfill": "^1.0.0"
       },
       "engines": {
-        "node": "8.* || >= 10.*"
+        "node": "14.* || 16.* || >= 18"
+      },
+      "peerDependencies": {
+        "ember-source": "*"
+      },
+      "peerDependenciesMeta": {
+        "ember-source": {
+          "optional": true
+        }
       }
     },
     "node_modules/tree-kill": {
@@ -36810,6 +36784,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "deprecated": "The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -94,6 +94,12 @@
     "tracked-built-ins": "^3.1.1",
     "webpack": "^5.78.0"
   },
+  "overrides": {
+    "@appuniversum/ember-appuniversum": {
+      "tracked-toolbox": "^2.0.0",
+      "ember-focus-trap": "~1.0.1"
+    }
+  },
   "engines": {
     "node": "14.* || 16.* || >= 18"
   },


### PR DESCRIPTION
## Overview

GN-4542: Fix issues reported by `dependency-lint`

* Pin `tracked-toolbox` to `^2.0.0` based on this comment - https://github.com/appuniversum/ember-appuniversum/pull/421#issuecomment-1706553230
* Pin `ember-focus-trap` to `1.0.1` based on this issue - https://github.com/josemarluedke/ember-focus-trap/issues/82

GN-4542: Enable `dependency-lint` on CI

#### Connected issues and PRs:

https://binnenland.atlassian.net/browse/GN-4543


### Setup

1. Checkout

### How to test/reproduce

1. Run `ember dependency-lint`, should return 0


### Checks PR readiness
- [X] UI: works on smaller screen sizes
- [X] UI: feedback for any loading/error states
- [X] Check cancel/go-back flows
- [X] Check database state correct when deleting/updating (especially regarding relationships)
- [X] changelog
- [X] npm lint
- [X] no new deprecations