### PR TITLE
add Citation card so keyword activation works for citation plugin

### DIFF
--- a/.changeset/hip-beds-brush.md
+++ b/.changeset/hip-beds-brush.md
@@ -1,0 +1,5 @@
+---
+"frontend-embeddable-notule-editor": patch
+---
+
+Add citation card to search for citations that activates when typing citation plugin keywords

--- a/app/components/simple-editor.hbs
+++ b/app/components/simple-editor.hbs
@@ -122,7 +122,6 @@
               {{#if (array-includes this.activePlugins 'citation')}}
                 <CitationPlugin::CitationInsert
                   @controller={{this.controller}}
-                  @plugin={{this.citationPlugin}}
                   @config={{this.config.citation}}
                 />
               {{/if}}
@@ -180,6 +179,13 @@
             {{#if (array-includes this.activePlugins 'template-comments')}}
               <TemplateCommentsPlugin::EditCard
                 @controller={{this.controller}}
+              />
+            {{/if}}
+            {{#if (array-includes this.activePlugins 'citation')}}
+              <CitationPlugin::CitationCard
+                @controller={{this.controller}}
+                @plugin={{this.citationPlugin}}
+                @config={{this.config.citation}}
               />
             {{/if}}
           </Sidebar>


### PR DESCRIPTION
## Overview
Citation card was missing, which meant that the **B.** option to activate citations (via keyword typing) did not work.

### How to test/reproduce
type one of the keywords (see readme) like `omzendbrief test` and see the card pop up on the right.
