### PR TITLE
remove all mentions of old separate rdfa-date plugin

### DIFF
--- a/.changeset/old-rivers-own.md
+++ b/.changeset/old-rivers-own.md
@@ -1,0 +1,5 @@
+---
+"frontend-embeddable-notule-editor": patch
+---
+
+remove some left over mentions of rdfa-date plugin in readme and code, as this is now fully encompassed in the variable plugin

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ window.addEventListener('load', function () {
     const editorContainer = document.getElementById('my-editor');
     const editorElement =
     editorContainer.getElementsByClassName('notule-editor')[0];
-    const arrayOfPluginNames = ['citation', 'rdfa-date'];
+    const arrayOfPluginNames = ['citation', 'variable'];
     const userConfigObject = {}
     editorElement.initEditor(arrayOfPluginNames, userConfigObject);
   });
@@ -127,7 +127,7 @@ const editorElement = editorContainer.getElementsByClassName('notule-editor')[0]
 After rendering the editor we can select the editorElement, which we do with the above code. We get the editorContainer in which we rendered our app, and then select the editor div that has the `notule-editor` class.
 
 ```javascript
-const arrayOfPluginNames = ['citation', 'rdfa-date'];
+const arrayOfPluginNames = ['citation', 'variable'];
 const userConfigObject = {}
 editorElement.initEditor(arrayOfPluginNames, userConfigObject);
 ```
@@ -207,7 +207,6 @@ Any configuration value not provided will use the default value, which are shown
 * [article-structure](#article-structure): Provides structures like titles, chapters, articles and paragraphs, which can be used to better manage official documents like regulatory statements. It allows you to insert, move and delete them.
 * [besluit](#besluit): Provides the correct rdfa-structure for constructing a decision (besluit) with ways to move and delete them.
 * [citation](#citation): Search and insert references to citations (a legal resource/expression)
-* [rdfa-date](#rdfa-date): Inserting and modifying annotated dates and times
 * [roadsign-regulation](#roadsign-regulation): Insert roadsign regulations, based on the registry managed and provided by MOW (Mobiliteit en Openbare Werken)
 * [table-of-contents](#table-of-contents): Show a table of contents with clickable sections defined by [article-structure](#article-structure)
 * [variable](#rdfa-variables): Allows insertion and filling in of custom rdfa variables

--- a/app/config/defaults.js
+++ b/app/config/defaults.js
@@ -1,7 +1,7 @@
 import merge from 'lodash.mergewith';
 
 /**
- * @type {import("@lblod/ember-rdfa-editor-lblod-plugins/plugins/rdfa-date-plugin/index").DateOptions}
+ * @type {import("@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/variables/date").DateOptions}
  */
 export const defaultRdfaDatePluginConfig = {
   formats: [

--- a/public/test.html
+++ b/public/test.html
@@ -54,7 +54,7 @@
           const editorContainer = document.getElementById('my-editor');
           const editorElement =
           editorContainer.getElementsByClassName('notule-editor')[0];
-          editorElement.initEditor(['citation', 'besluit','rdfa-date', 'article-structure', 'variable', 'table-of-contents',
+          editorElement.initEditor(['citation', 'besluit', 'article-structure', 'variable', 'table-of-contents',
                                          'roadsign-regulation', 'formatting-toggle', 'template-comments'], {
                                           docContent: 'table_of_contents? ((chapter|block)+|(title|block)+|(article|block)+)',
                                           citation: {


### PR DESCRIPTION
## Overview
rdfa-date plugin was merged inside the variable plugin in https://github.com/lblod/ember-rdfa-editor-lblod-plugins/releases/tag/v13.0.0
But some places still mentioned this old plugin. This PR removes those.

### How to test/reproduce
Nothing should have changed in how Embeddable works. The example in the readme should still work.
But really just a code review is enough for this :) 