### PR TITLE
GN-4562: Document overriding CSS

### DIFF
--- a/.changeset/small-fans-fold.md
+++ b/.changeset/small-fans-fold.md
@@ -1,0 +1,5 @@
+---
+"@lblod/embeddable-say-editor": minor
+---
+
+GN-4562: Inform user how to apply CSS overrides

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ The editor can be customized to best fit your application.
 * [Managing Plugins](#managing-plugins): A list of plugins you can enable, including explanation of how to use them
 * [Environment banner](#enabling-disabling-the-environment-banner): how to enable/disable this banner
 * [Localization](#localization): language options in the editor
-* [styling](#styling)
+* [Styling](#styling)
 
 ## Managing Plugins
 Embeddable ships with the following plugins available. 
@@ -519,9 +519,45 @@ Localization of the editor is an ongoing effort, the main target usage of Embedd
 Some plugins, like the [citation plugin](#citation), use date pickers. The display format of these dates are connected with the local.
 
 The locale can be overwritten with `setLocaleToDutch()`, `setLocaleToEnglish()` and `setLocale(locale: string)`. You can call one of these functions after `initEditor()` to always use the same language for the editor, ignoring the user's browser language.
+
 ## Styling
-Styling the editor can be done by overriding some CSS variables as covered in the [README of ember-rdfa-editor](https://github.com/lblod/ember-rdfa-editor#customisation).For other customizations, override other CSS as usual. 
-Alternatively, the frontend supports SASS, which can be added to [app.scss](app/styles/app.scss) before building the Embeddable yourself.
+
+Styling the editor can be done in three ways
+
+* Setting CSS variables used by the editor. This is the recommended way to style the editor.
+* Targeting the editor and the classes used in the editor directly in your own CSS. This is prone to breakage when the editor changes, as we do not guarantee that class names will never change.
+* Alternatively, if you choose to build this application on your own - it supports SASS, which can be added to [app.scss](app/styles/app.scss) before building the Embeddable yourself.
+
+> [!CSS Variables]
+> If you choose to set the CSS variables you can use [the following manual as reference](https://github.com/lblod/ember-rdfa-editor#customisation) for the variable names.
+
+### Setting CSS variables when using the `npm` package
+
+When initializing editor with `renderEditor` pass an object `cssVariables` with the variables you want to set.
+
+```js
+const cssVariables = {
+  '--au-font': 'Comic Sans MS', 
+}
+
+const editor = await renderEditor({
+  // all other config options
+  cssVariables,
+})
+```
+
+### Setting CSS variables when using the prebuilt bundles
+
+After calling the `initEditor` on the `editorElement` you can use the snippet to modify CSS variables used by the editor
+
+```js
+// initialization code
+editorElement.initEditor(/* some config */);
+
+// Example of calling the setProperty method on the editorElement
+// Will set default font used by editor to Comic Sans MS
+editorElement.style.setProperty('--au-font', 'Comic Sans MS');
+```
 
 # Development of @lblod/embeddable-say-editor
 

--- a/README.md
+++ b/README.md
@@ -528,10 +528,15 @@ Styling the editor can be done in three ways
 * Targeting the editor and the classes used in the editor directly in your own CSS. This is prone to breakage when the editor changes, as we do not guarantee that class names will never change.
 * Alternatively, if you choose to build this application on your own - it supports SASS, which can be added to [app.scss](app/styles/app.scss) before building the Embeddable yourself.
 
-> [!CSS Variables]
-> If you choose to set the CSS variables you can use [the following manual as reference](https://github.com/lblod/ember-rdfa-editor#customisation) for the variable names.
 
-### Setting CSS variables when using the `npm` package
+### Setting CSS variables
+
+> [!CSS Variables]
+> If you choose to set the CSS variables you can use [this reference](https://appuniversum.github.io/ember-appuniversum/?path=/story/variables-css-variables--page).
+
+You will most likely want to change `--au-font` first to match font of your application.
+
+#### When using the `npm` package
 
 When initializing editor with `renderEditor` pass an object `cssVariables` with the variables you want to set.
 
@@ -546,7 +551,7 @@ const editor = await renderEditor({
 })
 ```
 
-### Setting CSS variables when using the prebuilt bundles
+#### When using the prebuilt bundles
 
 After calling the `initEditor` on the `editorElement` you can use the snippet to modify CSS variables used by the editor
 

--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ Styling the editor can be done in three ways
 
 ### Setting CSS variables
 
-> [!CSS Variables]
+> [!IMPORTANT]
 > If you choose to set the CSS variables you can use [this reference](https://appuniversum.github.io/ember-appuniversum/?path=/story/variables-css-variables--page).
 
 You will most likely want to change `--au-font` first to match font of your application.

--- a/README.md
+++ b/README.md
@@ -522,19 +522,12 @@ The locale can be overwritten with `setLocaleToDutch()`, `setLocaleToEnglish()` 
 
 ## Styling
 
-Styling the editor can be done in three ways
+Styling the editor is supported via setting the CSS Variables used by the editor. You can do it in two ways:
 
-* Setting CSS variables used by the editor. This is the recommended way to style the editor.
-* Targeting the editor and the classes used in the editor directly in your own CSS. This is prone to breakage when the editor changes, as we do not guarantee that class names will never change.
-* Alternatively, if you choose to build this application on your own - it supports SASS, which can be added to [app.scss](app/styles/app.scss) before building the Embeddable yourself.
+* Setting CSS Variables of the editor at runtime.
+* Target the editor in your own CSS and set CSS Variables of the editor in your own CSS.
 
-
-### Setting CSS variables
-
-> [!IMPORTANT]
-> If you choose to set the CSS variables you can use [this reference](https://appuniversum.github.io/ember-appuniversum/?path=/story/variables-css-variables--page).
-
-You will most likely want to change `--au-font` first to match font of your application.
+### Setting CSS variables at runtime
 
 #### When using the `npm` package
 
@@ -542,7 +535,7 @@ When initializing editor with `renderEditor` pass an object `cssVariables` with 
 
 ```js
 const cssVariables = {
-  '--au-font': 'Comic Sans MS', 
+  '--say-font-family': 'Comic Sans MS', 
 }
 
 const editor = await renderEditor({
@@ -561,8 +554,28 @@ editorElement.initEditor(/* some config */);
 
 // Example of calling the setProperty method on the editorElement
 // Will set default font used by editor to Comic Sans MS
-editorElement.style.setProperty('--au-font', 'Comic Sans MS');
+editorElement.style.setProperty('--say-font-family', 'Comic Sans MS');
 ```
+
+### Setting CSS variables by targeting the editor in your own CSS
+
+> [!IMPORTANT]
+> This wont work if you are using the `npm` package and the `renderEditor` it provides, as the editor is isolated inside an `iframe`.
+
+This method uses the CSS specificity to override the default CSS variables used by the editor.
+You can target the editor by using the `notule-editor` class on the element that contains the editor.
+
+Below example expects that the editor was attached to an element with id `my-editor`.
+
+```css
+#my-editor .notule-editor {
+  --say-font-family: 'Comic Sans MS';
+}
+```
+
+### Exposed CSS variables
+
+* `--say-font-family`: controls the font family used by the editor.
 
 # Development of @lblod/embeddable-say-editor
 

--- a/README.md
+++ b/README.md
@@ -576,6 +576,14 @@ Below example expects that the editor was attached to an element with id `my-edi
 ### Exposed CSS variables
 
 * `--say-font-family`: controls the font family used by the editor.
+* `--say-page-bg`: controls the background of the editor (not the background of the editor's page).
+* `--say-font-size-text`: size of the basic text in the editor.
+* `--say-font-size-h1`: size of the Heading 1 in the editor.
+* `--say-font-size-h2`: size of the Heading 2 in the editor.
+* `--say-font-size-h3`: size of the Heading 3 in the editor.
+* `--say-font-size-h4`: size of the Heading 4 in the editor.
+* `--say-font-size-h5`: size of the Heading 5 in the editor.
+* `--say-font-size-h6`: size of the Heading 6 in the editor.
 
 # Development of @lblod/embeddable-say-editor
 

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -33,3 +33,13 @@ div.table-of-contents {
     list-style-type: none !important;
   }
 }
+
+@mixin variables {
+  // Font
+  --default-font-family: "flanders-sans", BlinkMacSystemFont, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --au-font: var(--say-font-family, var(--default-font-family));
+}
+
+.notule-editor {
+  @include variables;
+}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,4 +1,3 @@
-
 // Appuniversum theme
 @import "ember-power-select";
 @import "ember-appuniversum";
@@ -34,12 +33,42 @@ div.table-of-contents {
   }
 }
 
-@mixin variables {
-  // Font
+.notule-editor {
+  // VARIABLES START
+
+  // Font Family
   --default-font-family: "flanders-sans", BlinkMacSystemFont, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   --au-font: var(--say-font-family, var(--default-font-family));
-}
 
-.notule-editor {
-  @include variables;
+  // Font Size
+  --default-text-font-size: 15px;
+  --default-h1-font-size: 44px;
+  --default-h2-font-size: 32px;
+  --default-h3-font-size: 26px;
+  --default-h4-font-size: 20px;
+  --default-h5-font-size: 18px;
+  --default-h6-font-size: 16px;
+
+  // Background color
+  --default-bg-color: #f7f9fc;
+
+  // VARIABLES END
+
+  // TODO: Create a variable inside the editor repo itself, so we can target it instead of using selectors.
+  //       Using this approach for a proof of concept.
+  .say-container--paper .say-editor {
+    background-color: var(--say-page-bg, var(--default-bg-color));
+  }
+
+  .say-content {
+    $headings: h1, h2, h3, h4, h5, h6;
+
+    font-size: var(--say-font-size-text, var(--default-text-font-size));
+
+    @each $heading in $headings {
+      #{$heading} {
+        font-size: var(--say-font-size-#{$heading}, var(--default-#{$heading}-font-size));
+      }
+    }
+  }
 }

--- a/main.js
+++ b/main.js
@@ -34,6 +34,7 @@ const srcDoc = `
  * and options. It waits for everything to initialize and returns the fully initialized
  * editor element, which has access to a controller and other methods (see docs)
  * @param {RenderOpts} options
+ * @param {Object.<string, string>} Record of CSS Variables and their values to be applied to the editor
  * @returns the enhanced editor element.
  */
 export async function renderEditor({
@@ -43,6 +44,7 @@ export async function renderEditor({
   height,
   plugins = [],
   options = {},
+  cssVariables = {},
 }) {
   // build the iframe
   const editorFrame = document.createElement('iframe');
@@ -107,6 +109,13 @@ export async function renderEditor({
   frameDoc.removeChild(embeddableScript);
   // initialize the editor
   await editorElement.initEditor(plugins, options);
+
+  if (cssVariables && Object.keys(cssVariables).length > 0) {
+    Object.entries(cssVariables).forEach(([key, value]) => {
+      editorElement.style.setProperty(key, value);
+    });
+  }
+
   return editorElement;
 }
 

--- a/public/test.html
+++ b/public/test.html
@@ -30,7 +30,7 @@
       </button>
       <div>
         Environment banner
-        <input type="checkbox" id="environment-banner" checked="checked" /> 
+        <input type="checkbox" id="environment-banner" checked="checked" />
       </div>
     </div>
     <div


### PR DESCRIPTION
## Overview

Update a guide for the user on how to override/set CSS Variables for the editor (which are mostly App Universum variables).

I thought at first that I should update Editor and Plugins to accept options with CSS variables that should be overriden, and do overrides on editor initialize with extra JS shennanigans, but there is not need for that, as we can just override CSS Variables whenever we want.

##### connected issues and PRs:

https://binnenland.atlassian.net/browse/GN-4562

### Setup
1. Checkout
2. Build

Rendered README is here - https://github.com/lblod/frontend-embeddable-notule-editor/blob/a2795f7286871be0c439796da3a12b9ca410cc8e/README.md

### How to test/reproduce
1. Try to use `renderEditor` with you app setup of choice while passing `cssVariables` as documented

### Challenges/uncertainties

"Gewone tekst" button does not accept `--au-font` it seems. For some reason it is "Arial" for me. Wasted half a day on trying to understand how to fix it, likely needs to be fixed inside the App Universum, likely an issue with specificity (as always)

![CleanShot 2023-10-30 at 15 57 48@2x](https://github.com/lblod/frontend-embeddable-notule-editor/assets/769698/18d13075-a072-4094-b4ce-c9f6fb252d18)

Something similar might be happening to other variables too. 

### Checks PR readiness
- [X] UI: works on smaller screen sizes
- [X] UI: feedback for any loading/error states
- [X] Check cancel/go-back flows
- [X] Check database state correct when deleting/updating (especially regarding relationships)
- [X] changelog
- [X] npm lint
- [X] no new deprecations