### PR TITLE
GN-4615: Fix display of some SVG icons

### DIFF
--- a/.changeset/wild-buckets-accept.md
+++ b/.changeset/wild-buckets-accept.md
@@ -1,0 +1,8 @@
+---
+"@lblod/embeddable-say-editor": patch
+---
+
+GN-4615: Fix display of some SVG icons
+
+Overrides "fill" attribute of "g" elements with `fill="none"` with `fill="currentColor"`  
+to make sure we see the icons. This is an artifact of using `svg-jar` to inline the icons.

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -72,3 +72,10 @@ div.table-of-contents {
     }
   }
 }
+
+.au-c-icon {
+  g[fill="none"] {
+    fill: currentColor;
+  }
+}
+


### PR DESCRIPTION
## Overview

GN-4615: Fix display of some SVG icons

Overrides "fill" attribute of "g" elements with `fill="none"` with `fill="currentColor"`  
to make sure we see the icons. This is an artifact of using `svg-jar` to inline the icons.

##### connected issues and PRs:

https://binnenland.atlassian.net/browse/GN-4615


### Setup

1. Checkout

### How to test/reproduce

1. Make sure you still see the icons in the menu
2. Make sure you see the "remove link" icon

![CleanShot 2023-11-29 at 12 57 51@2x](https://github.com/lblod/frontend-embeddable-notule-editor/assets/769698/e15e054b-fb1a-4a61-b3b0-5367f43ead23)


### Checks PR readiness
- [X] UI: works on smaller screen sizes
- [X] UI: feedback for any loading/error states
- [X] Check cancel/go-back flows
- [X] Check database state correct when deleting/updating (especially regarding relationships)
- [X] changelog
- [X] npm lint
- [X] no new deprecations