### PR TITLE
GN-4610: Remove `endpoint` config for citation plugin

### DIFF
--- a/.changeset/pink-years-design.md
+++ b/.changeset/pink-years-design.md
@@ -1,0 +1,7 @@
+---
+"@lblod/embeddable-say-editor": patch
+---
+
+GN-4610: Remove `endpoint` config for citation plugin
+
+Remove the `endpoint` config for the citation plugin used in the `test.html` file.

--- a/public/test.html
+++ b/public/test.html
@@ -60,7 +60,6 @@
                                           citation: {
                                             type: 'ranges',
                                             activeInRanges: (state) => [[0, state.doc.content.size]],
-                                            endpoint: 'https://codex.opendata.api.vlaanderen.be:8888/sparql',
                                           }
                                          });
           editorElement.enableEnvironmentBanner();


### PR DESCRIPTION
## Overview

GN-4610: Remove `endpoint` config for citation plugin

Remove the `endpoint` config for the citation plugin used in the `test.html` file.

Should aid in fixing the citation plugin on https://embeddable.gelinkt-notuleren.lblod.info/



### Checks PR readiness
- [X] UI: works on smaller screen sizes
- [X] UI: feedback for any loading/error states
- [X] Check cancel/go-back flows
- [X] Check database state correct when deleting/updating (especially regarding relationships)
- [X] changelog
- [X] npm lint
- [X] no new deprecations