### PR TITLE
Disable `space` invisible from formatting marks in order to improve performance

### DIFF
--- a/.changeset/lucky-foxes-call.md
+++ b/.changeset/lucky-foxes-call.md
@@ -1,0 +1,5 @@
+---
+"@lblod/embeddable-say-editor": minor
+---
+
+Remove `space` invisible from formatting marks in order to improve performance

--- a/app/components/simple-editor.js
+++ b/app/components/simple-editor.js
@@ -61,7 +61,6 @@ import {
   hardBreak,
   heading as headingInvisible,
   paragraph as paragraphInvisible,
-  space,
 } from '@lblod/ember-rdfa-editor/plugins/invisibles';
 
 import {
@@ -262,7 +261,7 @@ export default class SimpleEditorComponent extends Component {
       firefoxCursorFix(),
       lastKeyPressedPlugin,
       createInvisiblesPlugin(
-        [space, hardBreak, paragraphInvisible, headingInvisible],
+        [hardBreak, paragraphInvisible, headingInvisible],
         {
           shouldShowInvisibles: false,
         }


### PR DESCRIPTION
## Overview
This PR disables the `space` invisible in this application as it causes large slowdowns when pasting large documents/typing in large documents.

The other formatting marks (pilcrow and carriage return) do not cause a large slowdown as they are way more sparse.

##### connected issues and PRs:
[GN-4617](https://binnenland.atlassian.net/browse/GN-4617?atlOrigin=eyJpIjoiODUxN2E2NWYzZWQ0NGMxMDk0NzNlNmUxNDEwY2I4ZTUiLCJwIjoiaiJ9)
https://github.com/lblod/ember-rdfa-editor/pull/1057

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations