### PR TITLE
GN-4625: Expose CSS variable to adjust line spacing

### DIFF
--- a/.changeset/cold-hats-ring.md
+++ b/.changeset/cold-hats-ring.md
@@ -1,0 +1,8 @@
+---
+"@lblod/embeddable-say-editor": minor
+---
+
+GN-4625: Expose CSS variable to adjust line spacing
+
+* `--say-paragraph-spacing`: spacing between paragraphs, default is 12px.
+* `--say-editor-line-height`: line height of the editor, default is 1.5.

--- a/README.md
+++ b/README.md
@@ -709,6 +709,9 @@ Below example expects that the editor was attached to an element with id `my-edi
 * `--say-font-size-h5`: size of the Heading 5 in the editor.
 * `--say-font-size-h6`: size of the Heading 6 in the editor.
 
+* `--say-paragraph-spacing`: spacing between paragraphs, default is 12px.
+* `--say-editor-line-height`: line height of the editor, default is 1.5.
+
 # Development of @lblod/embeddable-say-editor
 
 ## Prerequisites

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -52,6 +52,9 @@ div.table-of-contents {
   // Background color
   --default-bg-color: #f7f9fc;
 
+  // Spacing
+  --default-paragraph-spacing: 12px;
+
   // VARIABLES END
 
   // TODO: Create a variable inside the editor repo itself, so we can target it instead of using selectors.
@@ -69,6 +72,12 @@ div.table-of-contents {
       #{$heading} {
         font-size: var(--say-font-size-#{$heading}, var(--default-#{$heading}-font-size));
       }
+    }
+
+    line-height: var(--say-editor-line-height, var(--au-global-line-height));
+
+    p + * {
+      margin-top: var(--say-paragraph-spacing, var(--default-paragraph-spacing));
     }
   }
 }


### PR DESCRIPTION
## Overview

GN-4625: Expose CSS variable to adjust line spacing

Build on top of previous approach with `Exposed CSS variables`

##### connected issues and PRs:

https://binnenland.atlassian.net/browse/GN-4625


### Setup

1. Checkout
2. `npm run build`
3. `npm run start`

### How to test/reproduce

See video or add `--say-paragraph-spacing` on `--say-editor-line-height` on `.notule-editor` container and adjust their values.

https://github.com/lblod/frontend-embeddable-notule-editor/assets/769698/454dd955-f04b-4f1b-8598-1b2a3555f525

### Challenges/uncertainties

`--say-editor-line-height` adjusts `line-height` for all content, not just the "top level" paragraphs. I think that is normal behaviour, as I'd want to have adjusted line height for all of the content, not just my "standalone" paragraphs, IMO.

### Checks PR readiness
- [X] UI: works on smaller screen sizes
- [X] UI: feedback for any loading/error states
- [X] Check cancel/go-back flows
- [X] Check database state correct when deleting/updating (especially regarding relationships)
- [X] changelog
- [X] npm lint
- [X] no new deprecations