### PR TITLE
Only show the sidebar and insert heading if relevant to installed plugins

### DIFF
--- a/.changeset/five-falcons-add.md
+++ b/.changeset/five-falcons-add.md
@@ -1,0 +1,5 @@
+---
+"@lblod/embeddable-say-editor": patch
+---
+
+Hide the sidebar or insert menu when there are no plugins that make use of them.

--- a/app/components/simple-editor.hbs
+++ b/app/components/simple-editor.hbs
@@ -17,6 +17,7 @@
         showToolbarBottom=null
       }}
       @showRdfaBlocks={{this.controller.showRdfaBlocks}}
+      @hideSidebar={{(not this.config.sidebar)}}
     >
       <:top>
         {{#if this.controller}}
@@ -111,41 +112,42 @@
       <:aside>
         {{#if this.controller}}
           <Sidebar as |Sidebar|>
-            <Sidebar.Collapsible @title={{t "editor.insert"}}>
-              {{#if (array-includes this.activePlugins 'besluit')}}
-                <div class="au-u-medium">{{t 'editor.besluit.title'}}</div>
-                <ArticleStructurePlugin::ArticleStructureCard
-                  @controller={{this.controller}}
-                  @options={{this.config.besluit.structures}}
-                />
-              {{/if}}
-              {{#if (array-includes this.activePlugins 'article-structure')}}
-                <div class="au-u-medium">{{t 'editor.article-structure.title'}}</div>
-                <ArticleStructurePlugin::ArticleStructureCard
-                  @controller={{this.controller}}
-                  @options={{this.config.articleStructure.structures}}
-                />
-              {{/if}}
-              <div class="au-u-medium">{{t 'editor.others.title'}}</div>
-              {{#if (array-includes this.activePlugins 'citation')}}
-                <CitationPlugin::CitationInsert
-                  @controller={{this.controller}}
-                  @config={{this.config.citation}}
-                />
-              {{/if}}
-              {{#if (array-includes this.activePlugins 'roadsign-regulation')}}
-                <RoadsignRegulationPlugin::RoadsignRegulationCard
-                  @controller={{this.controller}}
-                  @options={{this.config.roadsignRegulation}}
-                />
-              {{/if}}
-              {{#if (array-includes this.activePlugins 'template-comments')}}
-                <TemplateCommentsPlugin::Insert
-                  @controller={{this.controller}}
-                />
-              {{/if}}
-
-            </Sidebar.Collapsible>
+            {{#if this.uiConfig.insertMenu}}
+              <Sidebar.Collapsible @title={{t "editor.insert"}}>
+                {{#if (array-includes this.activePlugins 'besluit')}}
+                  <div class="au-u-medium">{{t 'editor.besluit.title'}}</div>
+                  <ArticleStructurePlugin::ArticleStructureCard
+                    @controller={{this.controller}}
+                    @options={{this.config.besluit.structures}}
+                  />
+                {{/if}}
+                {{#if (array-includes this.activePlugins 'article-structure')}}
+                  <div class="au-u-medium">{{t 'editor.article-structure.title'}}</div>
+                  <ArticleStructurePlugin::ArticleStructureCard
+                    @controller={{this.controller}}
+                    @options={{this.config.articleStructure.structures}}
+                  />
+                {{/if}}
+                <div class="au-u-medium">{{t 'editor.others.title'}}</div>
+                {{#if (array-includes this.activePlugins 'citation')}}
+                  <CitationPlugin::CitationInsert
+                    @controller={{this.controller}}
+                    @config={{this.config.citation}}
+                  />
+                {{/if}}
+                {{#if (array-includes this.activePlugins 'roadsign-regulation')}}
+                  <RoadsignRegulationPlugin::RoadsignRegulationCard
+                    @controller={{this.controller}}
+                    @options={{this.config.roadsignRegulation}}
+                  />
+                {{/if}}
+                {{#if (array-includes this.activePlugins 'template-comments')}}
+                  <TemplateCommentsPlugin::Insert
+                    @controller={{this.controller}}
+                  />
+                {{/if}}
+              </Sidebar.Collapsible>
+            {{/if}}
             {{#if (array-includes this.activePlugins 'article-structure')}}
               <ArticleStructurePlugin::StructureCard
                 @controller={{this.controller}}

--- a/app/components/simple-editor.js
+++ b/app/components/simple-editor.js
@@ -121,6 +121,7 @@ export default class SimpleEditorComponent extends Component {
   @tracked nodeViews;
   @tracked activePlugins;
   @tracked citationPlugin;
+  @tracked hasSidebarPlugins;
   @service intl;
 
   get vocabString() {
@@ -275,7 +276,16 @@ export default class SimpleEditorComponent extends Component {
       ),
     ];
     const nodeViews = {};
-    const setup = { nodes, marks, plugins, nodeViews, userConfig, config };
+    const setup = {
+      nodes,
+      marks,
+      plugins,
+      nodeViews,
+      userConfig,
+      config,
+      // Control whether UI aspects are needed
+      uiConfig: { insertMenu: false, sidebar: false },
+    };
     if (activePlugins.includes('citation')) {
       this.setupCitationPlugin(setup);
     }
@@ -301,6 +311,7 @@ export default class SimpleEditorComponent extends Component {
       this.setupConfidentialityPlugin(setup);
     }
     this.config = setup.config;
+    this.uiConfig = setup.uiConfig;
     setup.nodes = { ...setup.nodes, heading, invisible_rdfa, block_rdfa };
     this.schema = new Schema({ nodes: setup.nodes, marks: setup.marks });
 
@@ -323,7 +334,7 @@ export default class SimpleEditorComponent extends Component {
     await editorPromise;
   }
 
-  setupCitationPlugin({ userConfig, config, plugins }) {
+  setupCitationPlugin({ userConfig, config, plugins, uiConfig }) {
     config.citation = mergeConfigs(
       defaultCitationPluginConfig,
       userConfig.citation
@@ -332,6 +343,8 @@ export default class SimpleEditorComponent extends Component {
     const citationPluginVariable = citationPlugin(config.citation);
     this.citationPlugin = citationPluginVariable;
     plugins.push(citationPluginVariable);
+    uiConfig.insertMenu = true;
+    uiConfig.sidebar = true;
   }
 
   setupArticleStructurePlugin(setup) {
@@ -339,6 +352,8 @@ export default class SimpleEditorComponent extends Component {
     config.articleStructure = {};
     config.articleStructure.structures = STRUCTURE_SPECS;
     setup.nodes = { ...setup.nodes, ...STRUCTURE_NODES };
+    setup.uiConfig.insertMenu = true;
+    setup.uiConfig.sidebar = true;
   }
 
   setupBesluitPlugin(setup) {
@@ -346,6 +361,8 @@ export default class SimpleEditorComponent extends Component {
     config.besluit = {};
     config.besluit.structures = besluitStructure;
     setup.nodes = { ...setup.nodes, ...besluitNodes };
+    setup.uiConfig.insertMenu = true;
+    setup.uiConfig.sidebar = true;
   }
 
   setupRoadsignPlugin(setup) {
@@ -357,6 +374,8 @@ export default class SimpleEditorComponent extends Component {
       defaultRoadsignRegulationPluginConfig,
       userConfig.roadsignRegulation
     );
+    setup.uiConfig.insertMenu = true;
+    setup.uiConfig.sidebar = true;
   }
 
   setupVariablePlugin(setup) {
@@ -439,6 +458,8 @@ export default class SimpleEditorComponent extends Component {
     nodeViews.codelist = (controller) => codelistView(controller);
     nodeViews.date = (controller) =>
       dateView(config.variable.edit.date)(controller);
+
+    setup.uiConfig.sidebar = true;
   }
 
   setupTOCPlugin(setup) {
@@ -459,6 +480,8 @@ export default class SimpleEditorComponent extends Component {
     const { nodes, nodeViews } = setup;
     nodes.templateComment = templateComment;
     nodeViews.templateComment = (controller) => templateCommentView(controller);
+    setup.uiConfig.insertMenu = true;
+    setup.uiConfig.sidebar = true;
   }
 
   setupConfidentialityPlugin(setup) {


### PR DESCRIPTION
## Overview
In the configuration method for each plugin, flag which UI elements it needs and only show the relevant ones for the installed plugins.

It would be nice to be able to define these elements more dynamically, for example definining the template and where it will be placed in these set-up functions, but I wasn't able to think of a good way to do this.

##### connected issues and PRs:
Requires https://github.com/lblod/ember-rdfa-editor/pull/1106 to actually remove the whole sidebar.

### Setup
Link the relevant editor PR.

### How to test/reproduce
Remove any plugins that use the sidebar from test.html and see that the sidebar is hidden. Adding back any one of these will show the relevant parts of the sidebar.

### Challenges/uncertainties
Ember constraints. It would be nice if Ember had a (has-block-content) helper which treated an empty block as false, or allowed conditional named blocks, but it does not.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations