### PR TITLE
Add option to have the insertmenu open at launch

### DIFF
--- a/.changeset/late-knives-relax.md
+++ b/.changeset/late-knives-relax.md
@@ -1,0 +1,5 @@
+---
+"@lblod/embeddable-say-editor": minor
+---
+
+Add option to have the insert menu open on first load

--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ Any configuration value not provided will use the default value, which are shown
 There are some options you can pass to `pluginsConfig` in `initEditor` that are not connected to a plugin.
 - `docContent: 'block+'`: The property docContent specifies which nodes are allowed in the document. By default we allow one or more nodes of the group block, which includes most content. A group can be seen as a supertype that includes multiple types. For more info about this check the [Prosemirror docs](https://prosemirror.net/docs/guide/#schema.content_expressions).  
   See `public/test.html` where `docContent` is specified to allow a [table of contents](#table-of-contents) and [article-structure](#article-structure) nodes in a specific order.
+- `ui: { expandInsertMenu: false }`: wether to automatically open the "insert" sidebar menu upon load.
 
 ### Article Structure
 This plugin is in charge of inserting and manipulating structures. There are several insertion buttons in the right sidebar under *Document Structuren*.

--- a/app/components/simple-editor.hbs
+++ b/app/components/simple-editor.hbs
@@ -113,7 +113,9 @@
         {{#if this.controller}}
           <Sidebar as |Sidebar|>
             {{#if this.uiConfig.insertMenu}}
-              <Sidebar.Collapsible @title={{t "editor.insert"}}>
+              <Sidebar.Collapsible
+                @title={{t "editor.insert"}}
+                @expandedInitially={{this.uiConfig.expandInsertMenu}}>
                 {{#if (array-includes this.activePlugins 'besluit')}}
                   <div class="au-u-medium">{{t 'editor.besluit.title'}}</div>
                   <ArticleStructurePlugin::ArticleStructureCard

--- a/app/components/simple-editor.js
+++ b/app/components/simple-editor.js
@@ -313,6 +313,7 @@ export default class SimpleEditorComponent extends Component {
     }
     this.config = setup.config;
     this.uiConfig = setup.uiConfig;
+    this.uiConfig.expandInsertMenu = userConfig.ui?.expandInsertMenu ?? false;
     setup.nodes = { ...setup.nodes, heading, invisible_rdfa, block_rdfa };
     this.schema = new Schema({ nodes: setup.nodes, marks: setup.marks });
 


### PR DESCRIPTION
## Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->

adds a new option category to the config object: `ui`, with a single `expandInsertMenu` option
which is false by default. Setting it to true makes it so the insert menu is
expanded on load rather than closed.
##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->


### Setup
<!-- PR dependencies -->
<!-- override snippets -->

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

ember serve, then add the new option to the config object we pass to initEditor
### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [x] changelog
- [x] npm lint
- [x] no new deprecations