### PR TITLE
GN-4670: Fix column resized handles

### DIFF
--- a/.changeset/seven-weeks-enjoy.md
+++ b/.changeset/seven-weeks-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@lblod/embeddable-say-editor": patch
+---
+
+GN-4670: Fix column resize handles

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -80,6 +80,10 @@ div.table-of-contents {
     p + * {
       margin-top: var(--say-paragraph-spacing, var(--default-paragraph-spacing));
     }
+
+    .column-resize-handle {
+      margin-top: 0;
+    }
   }
 }
 


### PR DESCRIPTION
## Overview

`.column-resize-handle` selector from `editor` was loosing in the specificity battle to `.say-content p + *` selector inside embeddable, specifically the `margin-top` was getting overriden. This PR is the fix.

##### connected issues and PRs:

https://binnenland.atlassian.net/browse/GN-4670


### Setup

1. Checkout
2. `npm i`
3. `npm run start`

### How to test/reproduce

|Before|After|
|-|-|
| ![image](https://github.com/lblod/frontend-embeddable-notule-editor/assets/769698/e9810e80-0c79-4b85-9141-77e9e2ade4c0) | <img width="178" alt="CleanShot 2024-01-16 at 15 20 50@2x" src="https://github.com/lblod/frontend-embeddable-notule-editor/assets/769698/a320bdca-9532-4312-83a3-2ee5f2d75ae8"> |

### Checks PR readiness
- [X] UI: works on smaller screen sizes
- [X] UI: feedback for any loading/error states
- [X] Check cancel/go-back flows
- [X] Check database state correct when deleting/updating (especially regarding relationships)
- [X] changelog
- [X] npm lint
- [X] no new deprecations