### PR TITLE
Introduce `growEditor` option

### DIFF
--- a/.changeset/tender-actors-jog.md
+++ b/.changeset/tender-actors-jog.md
@@ -1,0 +1,9 @@
+---
+"@lblod/embeddable-say-editor": minor
+---
+
+Introduce `growEditor` option
+
+`growEditor` is a boolean option that allows the editor to grow in height as the content grows, instead of  
+having a fixed height and a scrollbar.
+

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ const editor = await renderEditor({
   title: 'my editor', // optional, this will set the "title" attribute of the iframe
   width: '500px', // width attribute of the iframe
   height: '300px', // height attribute of the iframe
+  growEditor: true, // optional, if true the editor will grow to fit the content, this will disregard the height attribute
   plugins: [], // array of plugin names (see below)
   options: {} // configuration object (see below)
   })
@@ -112,9 +113,10 @@ window.addEventListener('load', async function() {
     element: editorContainer,
     title: 'my editor', // optional, this will set the "title" attribute of the iframe
     width: '500px', // width attribute of the iframe
+    growEditor: true, // optional, if true the editor will grow to fit the content, this will disregard the height attribute
     height: '300px', // height attribute of the iframe
     plugins: [], // array of plugin names (see below)
-    options: {} // configuration object (see below)
+    options: {}, // configuration object (see below)
   })
   await editorElement.initEditor(arrayOfPluginNames, userConfigObject);
 })

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -85,6 +85,16 @@ div.table-of-contents {
       margin-top: 0;
     }
   }
+
+  .say-editor__paper {
+    &.min-content {
+      min-height: min-content;
+
+      .say-content {
+        min-height: min-content;
+      }
+    }
+  }
 }
 
 .au-c-icon {

--- a/public/multiple-growing-editors.html
+++ b/public/multiple-growing-editors.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>I have an editor in my document</title>
+  <meta charset="utf-8" />
+  <style>
+    iframe {
+      margin: 0;
+      padding: 0;
+      border: 1px solid lightgray;
+      border-radius: 8px;
+    }
+
+    body {
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    .demo-header {
+      display: flex;
+      justify-content: space-between;
+    }
+
+    .demo-content {
+      height: 100%;
+      overflow: hidden;
+      width: 100%;
+    }
+
+    .notule-editor {
+      height: 100%;
+    }
+
+    .editor-container {
+      /* element centered in the window  */
+      display: grid;
+      gap: 20px;
+      align-items: center;
+      width: 80%;
+    }
+  </style>
+  <script src="embeddable.js"></script>
+</head>
+
+<body>
+<div class="editor-container">
+  <div
+    id="editor-1"
+    class="demo-content"
+    prefix="besluit: http://data.vlaanderen.be/ns/besluit#"
+  ></div>
+  <div
+    id="editor-2"
+    class="demo-content"
+    prefix="besluit: http://data.vlaanderen.be/ns/besluit#"
+  ></div>
+  <div
+    id="editor-3"
+    class="demo-content"
+    prefix="besluit: http://data.vlaanderen.be/ns/besluit#"
+  ></div>
+</div>
+
+<script>
+  window.addEventListener("load", async function() {
+    const renderEditor = window["@lblod/embeddable-say-editor"].renderEditor;
+
+    const containers = ["editor-1", "editor-2", "editor-3"];
+
+    containers.forEach(containerSelector => {
+      const editorContainer = document.getElementById(containerSelector);
+
+      renderEditor({
+        element: editorContainer,
+        title: "test editor",
+        width: "800",
+        height: "200",
+        growEditor: true,
+        plugins: ["citation", "besluit", "article-structure", "table-of-contents",
+          "roadsign-regulation", "formatting-toggle", "template-comments", "confidentiality"],
+        options: {
+          docContent: "table_of_contents? ((chapter|block)+|(title|block)+|(article|block)+)",
+          citation: {
+            type: "ranges",
+            activeInRanges: (state) => [[0, state.doc.content.size]]
+          }
+        }
+      });
+    });
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Overview

Introduce `growEditor` option.

`growEditor` is a boolean option that allows the editor to grow in height as the content grows, instead of  
having a fixed height and a scrollbar.

##### connected issues and PRs:

???

### Setup

1. Checkout
2. `npm i` 

### How to test/reproduce

1. `npm run dev`
2. http://localhost:4100/multiple-growing-editors.html

Observe

https://github.com/lblod/frontend-embeddable-notule-editor/assets/769698/3f1eaa1d-6852-423a-abcf-7469329ee217


### Challenges/uncertainties

Need to implement for WebComponent as well @abeforgit?


### Checks PR readiness
- [X] UI: works on smaller screen sizes
- [X] UI: feedback for any loading/error states
- [X] Check cancel/go-back flows
- [X] Check database state correct when deleting/updating (especially regarding relationships)
- [X] changelog
- [X] npm lint
- [X] no new deprecations