### PR TITLE
GN-4713: Include mention of paragraph markers in README

### DIFF
--- a/.changeset/perfect-kids-help.md
+++ b/.changeset/perfect-kids-help.md
@@ -1,0 +1,5 @@
+---
+"@lblod/embeddable-say-editor": patch
+---
+
+GN-4713: Include mention of paragraph markers in README to make it more discoverable

--- a/.release-it.json
+++ b/.release-it.json
@@ -6,7 +6,6 @@
   },
   "plugins": {
     "changesets-release-it-plugin": {}
-    }
   },
   "npm": {
     "publish": false,

--- a/README.md
+++ b/README.md
@@ -529,7 +529,7 @@ variable: {
 The serialization format of these variables uses rdfa to store its data.
 
 ### Formatting Toggle
-This will add a button *Toon opmaakmarkeringen* in the top toolbar. This toggles the visibility of all formatting marks of the document such as break lines, paragraphs...  
+This will add a button *Toon opmaakmarkeringen* in the top toolbar. This toggles the visibility of all formatting marks of the document such as break lines, paragraph markers and others.  
 ![document with formatting annotations](https://github.com/lblod/frontend-embeddable-notule-editor/assets/126079676/bfc7ff1e-b8e3-4220-b80c-b5456d58208e)
 
 ***

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "embeddable-say-editor",
+  "name": "frontend-embeddable-notule-editor",
   "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,


### PR DESCRIPTION
## Overview

We already have `invisibles` plugin enabled in embeddable, I've added an extra word in README to make it more discoverable when looking for "paragraph markers" 🙏 

##### connected issues and PRs:

https://binnenland.atlassian.net/browse/GN-4713

### Setup

Not needed

### How to test/reproduce

1. `npm run start` 
2. http://localhost:8081/plugins.html
3. See that you can enable invisibles markers in the drop down menu 


https://github.com/lblod/frontend-embeddable-notule-editor/assets/769698/50ebf917-da68-4380-82e1-943847ed155b


### Checks PR readiness
- [X] UI: works on smaller screen sizes
- [X] UI: feedback for any loading/error states
- [X] Check cancel/go-back flows
- [X] Check database state correct when deleting/updating (especially regarding relationships)
- [X] changelog
- [X] npm lint
- [X] no new deprecations