### PR TITLE
GN-4731: downgrade and pin appuniversum package to 2.15.0

### DIFF
--- a/.changeset/afraid-cats-look.md
+++ b/.changeset/afraid-cats-look.md
@@ -1,0 +1,5 @@
+---
+"@lblod/embeddable-say-editor": patch
+---
+
+Downgrade `@appuniversum/ember-appuniversum` to 2.15.0

--- a/embeddable-say-editor/package.json
+++ b/embeddable-say-editor/package.json
@@ -32,7 +32,7 @@
     "ember-intl": "^5.7.2"
   },
   "devDependencies": {
-    "@appuniversum/ember-appuniversum": "^2.18.0",
+    "@appuniversum/ember-appuniversum": "2.15.0",
     "@babel/core": "^7.23.9",
     "@babel/eslint-parser": "^7.23.10",
     "@babel/plugin-syntax-decorators": "^7.23.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "ember-intl": "^5.7.2"
       },
       "devDependencies": {
-        "@appuniversum/ember-appuniversum": "^2.18.0",
+        "@appuniversum/ember-appuniversum": "2.15.0",
         "@babel/core": "^7.23.9",
         "@babel/eslint-parser": "^7.23.10",
         "@babel/plugin-syntax-decorators": "^7.23.3",
@@ -89,6 +89,55 @@
       },
       "engines": {
         "node": "16.* || >= 18"
+      }
+    },
+    "embeddable-say-editor/node_modules/@appuniversum/ember-appuniversum": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@appuniversum/ember-appuniversum/-/ember-appuniversum-2.15.0.tgz",
+      "integrity": "sha512-Z77MTwJM7gWVt4rj6pckADETE+UxMtQD0vWSf+1aEedWqnDMWp853APlhJYz1VPq8xtfJL9g809XFQUmyHUN6A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.22.10",
+        "@duetds/date-picker": "^1.4.0",
+        "@embroider/macros": "^1.9.0",
+        "@floating-ui/dom": "^1.1.0",
+        "@glimmer/component": "^1.1.2",
+        "@glimmer/tracking": "^1.1.2",
+        "@zestia/ember-auto-focus": "^4.2.0",
+        "ember-auto-import": "^2.6.3",
+        "ember-cli-babel": "^7.26.11",
+        "ember-cli-htmlbars": "^6.3.0",
+        "ember-concurrency": "2.x || ^3.1.0",
+        "ember-data-table": "^2.1.0",
+        "ember-file-upload": "^7.0.3",
+        "ember-focus-trap": "^1.0.2",
+        "ember-modifier": "^3.2.7",
+        "ember-test-selectors": "^6.0.0",
+        "inputmask": "^5.0.7",
+        "merge-anything": "^5.1.3",
+        "tracked-toolbox": "^1.2.3"
+      },
+      "engines": {
+        "node": "14.* || 16.* || >= 18"
+      },
+      "optionalDependencies": {
+        "ember-power-select": "2.x || 3.x || 4.x || 5.x || 6.x || 7.x"
+      },
+      "peerDependencies": {
+        "ember-source": "^3.28.0 || ^4.0.0 || ^5.0.0"
+      }
+    },
+    "embeddable-say-editor/node_modules/@appuniversum/ember-appuniversum/node_modules/tracked-toolbox": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tracked-toolbox/-/tracked-toolbox-1.3.0.tgz",
+      "integrity": "sha512-KHfYLvNyRr0qQeXQPnmb6Z4JYZ0/47R7LjVwzUrsKc539eQi3Sz2z3mb7FJN9KgaJXVuM3GQ8zcwUFTf0hrOsQ==",
+      "dev": true,
+      "dependencies": {
+        "ember-cache-primitive-polyfill": "^1.0.0",
+        "ember-cli-babel": "^7.26.6"
+      },
+      "engines": {
+        "node": "8.* || >= 10.*"
       }
     },
     "embeddable-say-editor/node_modules/@lblod/ember-rdfa-editor": {
@@ -561,6 +610,7 @@
       "resolved": "https://registry.npmjs.org/@appuniversum/ember-appuniversum/-/ember-appuniversum-2.18.0.tgz",
       "integrity": "sha512-W67tWC3racq9Eq9ziV4heFhAPeoRG0ILPtjKmYwM0BeIQ8k+L6Fp3Vrnh741yQBERNkdAr6F8XQu4G8mNbkBow==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.22.10",
         "@duetds/date-picker": "^1.4.0",
@@ -18444,6 +18494,7 @@
       "resolved": "https://registry.npmjs.org/ember-focus-trap/-/ember-focus-trap-1.1.0.tgz",
       "integrity": "sha512-KxbCKpAJaBVZm+bW4tHPoBJAZThmxa6pI+WQusL+bj0RtAnGUNkWsVy6UBMZ5QqTQzf4EvGHkCVACVp5lbAWMQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@embroider/addon-shim": "^1.0.0",
         "focus-trap": "^6.7.1"


### PR DESCRIPTION
## Overview
Recently (as of version 2.16.0), the `@appuniversum/ember-appuniversum` started using ember template-imports (https://github.com/ember-template-imports/ember-template-imports) and the `.gjs`/`.gts` syntax. While this is definitely the way forward for ember components, it introduces some challenges for this package.

The `AuIcon` component of the `@appuniversum/ember-appuniversum` package references svg icons externally. While this is a good approach for applications, it is less useful for packages like these where we want to inline the svgs (to remove the need of hosting the svg icons seperately).

Until recently, we could circumvent this issue by overwriting the appuniversum `AuIcon` in this package, this solution is no longer always possible with ember-template-imports (you can read https://rfcs.emberjs.com/id/0496-handlebars-strict-mode/ for more information about this).

The temporary solution in this PR is to downgrade the `@appuniversum/ember-appuniversum` package to version 2.15.0 until we find a more permanent solution.

##### connected issues and PRs:
[GN-4731](https://binnenland.atlassian.net/browse/GN-4731?atlOrigin=eyJpIjoiYjI4MWY0NDkzYTA4NDk0OWE0OTA4OWM1N2E4MjM3NzIiLCJwIjoiaiJ9)


### How to test/reproduce
- Open the test-app on the plugins page
- Notice that the icons in the sidebar and link-editor are no longer missing.

### Challenges/uncertainties
Downgrading the appuniversum dependency gives us time for a more permanent solution which will probably encompass adding `svg-jar` support to the appuniversum package.



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations