### PR TITLE
Re-enable ci pipelines for building docker image of test-app

### DIFF
--- a/.woodpecker/.build-latest.yml
+++ b/.woodpecker/.build-latest.yml
@@ -1,0 +1,11 @@
+steps:
+  push-latest:
+    image: plugins/docker
+    settings:
+      repo: lblod/frontend-embeddable-notule-editor
+      dockerfile: test-app/Dockerfile
+      tags: latest
+    secrets: [ docker_username, docker_password ]
+when:
+  branch: master
+  event: push

--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -24,6 +24,14 @@ steps:
     when:
       ref:
         exclude: refs/tags/*-next.*
+  push-tagged-build:
+    image: plugins/docker
+    settings:
+      repo: lblod/frontend-embeddable-notule-editor
+      dockerfile: test-app/Dockerfile
+      tags: "${CI_COMMIT_TAG##v}"
+      purge: true
+    secrets: [ docker_username, docker_password ]
 when:
   event: tag
   ref: refs/tags/v*


### PR DESCRIPTION
## Overview
This PR re-enables the CI pipelines responsible for building a docker image of the `test-app` module.
This will reduce load on the `dev` server (but will of course again increase load on CI). I did not enable a dry build on PRs.
