### PR TITLE
Add jsdoc based type definitions to npm module

### DIFF
--- a/.changeset/fast-readers-reflect.md
+++ b/.changeset/fast-readers-reflect.md
@@ -1,0 +1,5 @@
+---
+"@lblod/embeddable-say-editor": patch
+---
+
+Add Typescript types generated from mostly existing JSDOCs

--- a/embeddable-say-editor/.gitignore
+++ b/embeddable-say-editor/.gitignore
@@ -6,6 +6,7 @@
 # compiled output
 /ember-build/
 /dist/
+/types/
 
 # misc
 /.env*

--- a/embeddable-say-editor/main.js
+++ b/embeddable-say-editor/main.js
@@ -23,6 +23,20 @@ const srcDoc = `
 const EDITOR_CONTAINER_ID = 'my-editor';
 
 /**
+ * @typedef {Object} EditorElement - A HTML element with the class `notule-editor`. These are functions available from the editor element. :warning: **`initEditor` has to be called before accessing any other methods**.
+ * @property {import("@lblod/ember-rdfa-editor/core/say-controller").default} controller - provides direct access to a [SayController](https://github.com/lblod/ember-rdfa-editor/blob/master/addon/core/say-controller.ts) object. See [controller API](controller-api).
+ * @property {(arrayOfPluginNames: string[], options: Record<string, any>) => Promise<>} initEditor - Initialize the editor by passing an array of plugin names that should be activated and an object that contains the configuration for the editor and its plugins. See {@link file://./README.md#managing-plugins} for more info.
+ * @property {() => void} enableEnvironmentBanner - enable the banner that shows the environment and versions of plugins used.
+ * @property {() => void} disableEnvironmentBanner - disable the banner.
+ * @property {(content: string) => void} setHtmlContent - set the HTML content inside the editor, overwriting all previous content.
+ * @property {() => string} getHtmlContent - Get the HTML content of the editor. This might be different than custom content set via `setHtmlContent`, because of HTML parsing logic.
+ * @property {() => void} setLocaleToDutch - Set the locale (language used) of the editor to Dutch.
+ * @property {() => void} setLocaleToEnglish - Set the locale (language used) of the editor to English.
+ * @property {() => string} getLocale - returns the current locale of the editor. This will be the user's browser locale, the set local with `setLocale`, or `nl-BE`/`en-US`, the supported languages. See more at [Localization](localization).
+ * @property {(locale: string) => void} setLocale - set the current locale of the editor. Any locale is accepted, but will fallback to `nl-BE` if it is not `nl-BE` or `en-US` (the supported languages).
+ */
+
+/**
  * Renders the editor in an iframe and initializes it with the passed in plugins
  * and options. It waits for everything to initialize and returns the fully initialized
  * editor element, which has access to a controller and other methods (see docs)
@@ -36,7 +50,7 @@ const EDITOR_CONTAINER_ID = 'my-editor';
  * @param {Record<string, any>} [options.options={}] - The options to initialize the editor with.
  * @param {Object.<string, string>} [options.cssVariables={}] - Record of CSS Variables and their values to be applied to the editor.
  * @param {boolean} [options.growEditor=false] - Whether the editor should grow to fit its content.
- * @returns {Promise<HTMLElement>} - Returns a promise that resolves to the fully initialized editor element.
+ * @returns {Promise<EditorElement>} - Returns a promise that resolves to the fully initialized editor element.
  */
 export async function renderEditor({
   element,

--- a/embeddable-say-editor/package.json
+++ b/embeddable-say-editor/package.json
@@ -7,19 +7,22 @@
     "url": "git+https://github.com/lblod/frontend-embeddable-notule-editor"
   },
   "main": "dist/index.js",
+  "types": "types/main.d.ts",
   "files": [
     "dist",
+    "types",
     "README"
   ],
   "license": "MIT",
   "author": "redpencil.io",
   "scripts": {
     "start": "concurrently \"npm:ember:watch\" \"npm:webpack:watch\"",
-    "build": "npm run ember:build && npm run webpack:build",
+    "build": "npm run ember:build && npm run webpack:build && npm run types:build",
     "ember:watch": "ember build --watch",
     "ember:build": "ember build --environment=production",
     "webpack:watch": "webpack --watch --env development",
     "webpack:build": "webpack",
+    "types:build": "tsc",
     "prepack": "npm run build",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",
@@ -87,6 +90,7 @@
     "qunit-dom": "^2.0.0",
     "sass": "^1.55.0",
     "tracked-built-ins": "^3.1.1",
+    "typescript": "~5.3.0",
     "webpack": "^5.78.0",
     "webpack-cli": "^5.1.4"
   },

--- a/embeddable-say-editor/tsconfig.json
+++ b/embeddable-say-editor/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "files": ["main.js"],
+  "compilerOptions": {
+    // Tell TypeScript to read JS files
+    "allowJs": true,
+    // Don't check the imports of main.js
+    "skipLibCheck": true,
+    // Generate d.ts files
+    "declaration": true,
+    // Only output types, not JS
+    "emitDeclarationOnly": true,
+    "outDir": "types",
+    // Maps type lookups to JS file instead of .d.ts file
+    "declarationMap": true
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,7 @@
         "qunit-dom": "^2.0.0",
         "sass": "^1.55.0",
         "tracked-built-ins": "^3.1.1",
+        "typescript": "~5.3.0",
         "webpack": "^5.78.0",
         "webpack-cli": "^5.1.4"
       },
@@ -137,6 +138,19 @@
       },
       "engines": {
         "node": "8.* || >= 10.*"
+      }
+    },
+    "embeddable-say-editor/node_modules/typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -33710,6 +33724,20 @@
       "license": "MIT",
       "dependencies": {
         "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/typescript-memoize": {


### PR DESCRIPTION
## Overview
Some types could be improved such as constraining plugin name strings and typing the config arguments.

##### connected issues and PRs:
N/A

### Setup
N/A

### How to test/reproduce
You should be able to change the filenames in the test-app to *.ts and see type information in your editor.

### Challenges/uncertainties
Spent way too long trying to figure out why just converting the main.js file to TS and using webpack ts-loader lead to broken code.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations