### PR TITLE
fix: make the toolbar always stable

### DIFF
--- a/.changeset/olive-dragons-lick.md
+++ b/.changeset/olive-dragons-lick.md
@@ -2,4 +2,6 @@
 "@lblod/embeddable-say-editor": patch
 ---
 
-fix toolbar scrolling in all instances
+Fix toolbar scrolling in all instances
+
+If you were using an explicit height set with the (undocumented) `cssVariables` argument to `renderEditor`, you can likely remove it now, the editor should now correctly scroll in any scenario.

--- a/.changeset/olive-dragons-lick.md
+++ b/.changeset/olive-dragons-lick.md
@@ -1,0 +1,5 @@
+---
+"@lblod/embeddable-say-editor": patch
+---
+
+fix toolbar scrolling in all instances

--- a/embeddable-say-editor/main.js
+++ b/embeddable-say-editor/main.js
@@ -21,6 +21,9 @@ const srcDoc = `
 `;
 
 const EDITOR_CONTAINER_ID = 'my-editor';
+// adjusting this won't actually change the toolbar height, this is just the constant
+// value of the height as given by the editor css
+const TOOLBAR_HEIGHT = '44px';
 
 /**
  * @typedef {Object} EditorElement - A HTML element with the class `notule-editor`. These are functions available from the editor element. :warning: **`initEditor` has to be called before accessing any other methods**.
@@ -157,7 +160,7 @@ export async function renderEditor({
     const mainContainer = editorContainer.getElementsByClassName(
       'say-container__main'
     )[0];
-    mainContainer.style.height = 'calc(100vh - 44px)';
+    mainContainer.style.height = `calc(100vh - ${TOOLBAR_HEIGHT})`;
   }
 
   return editorElement;

--- a/embeddable-say-editor/main.js
+++ b/embeddable-say-editor/main.js
@@ -7,7 +7,7 @@ import vendorCss from './ember-build/assets/vendor.css';
 
 const srcDoc = `
 <!DOCTYPE html>
-<html>
+<html style="overflow: hidden;">
   <head>
     <meta charset="utf-8" />
     <!-- Requirements for the style -->
@@ -153,6 +153,11 @@ export async function renderEditor({
     });
 
     resizeObserver.observe(frameDoc);
+  } else {
+    const mainContainer = editorContainer.getElementsByClassName(
+      'say-container__main'
+    )[0];
+    mainContainer.style.height = 'calc(100vh - 44px)';
   }
 
   return editorElement;

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
     },
     "embeddable-say-editor": {
       "name": "@lblod/embeddable-say-editor",
-      "version": "3.6.0-next.1",
+      "version": "3.6.0-next.2",
       "license": "MIT",
       "dependencies": {
         "ember-intl": "^5.7.2"
@@ -35741,10 +35741,10 @@
       }
     },
     "test-app": {
-      "version": "3.6.0-next.1",
+      "version": "3.6.0-next.2",
       "license": "MIT",
       "dependencies": {
-        "@lblod/embeddable-say-editor": "^3.6.0-next.1"
+        "@lblod/embeddable-say-editor": "^3.6.0-next.2"
       },
       "devDependencies": {
         "copy-webpack-plugin": "^12.0.2",

--- a/test-app/src/index.js
+++ b/test-app/src/index.js
@@ -4,7 +4,7 @@ import { router } from './router';
 const container = document.createElement('div');
 document.body.appendChild(router);
 document.body.appendChild(container);
-container.style.height = '90vh'
+container.style.height = '90vh';
 const editor = await renderEditor({
   element: container,
   title: 'my editor', // optional, this will set the "title" attribute of the iframe

--- a/test-app/src/index.js
+++ b/test-app/src/index.js
@@ -4,11 +4,12 @@ import { router } from './router';
 const container = document.createElement('div');
 document.body.appendChild(router);
 document.body.appendChild(container);
+container.style.height = '90vh'
 const editor = await renderEditor({
   element: container,
   title: 'my editor', // optional, this will set the "title" attribute of the iframe
   width: '100%', // width attribute of the iframe
-  height: '500px', // height attribute of the iframe
+  height: '100%', // height attribute of the iframe
   plugins: [], // array of plugin names (see below)
   options: {
     table: {


### PR DESCRIPTION
-------

## Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->

This eliminates the need for the cssVariables hack and just always makes
the toolbar stay at the top, except when growable is true

Uses a bit of css magic inline styles to force the overflow scrolling to only apply to the content div
##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->


### Setup
<!-- PR dependencies -->
<!-- override snippets -->

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->
note that scrolling is now fixed without having to adjust the editor configs
### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [ ] no new deprecations