### PR TITLE
Use version of plugins with bundled location markers

### DIFF
--- a/.changeset/sharp-hats-search.md
+++ b/.changeset/sharp-hats-search.md
@@ -1,0 +1,5 @@
+---
+"@lblod/embeddable-say-editor": minor
+---
+
+Use version of @lblod/ember-rdfa-editor-lblod-plugins that includes bundled markers for the location plugin

--- a/embeddable-say-editor/package.json
+++ b/embeddable-say-editor/package.json
@@ -56,7 +56,7 @@
     "@glint/template": "^1.5.2",
     "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-rdfa-editor": "11.3.0",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "28.1.0",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "28.2.0-dev.85da5ade4142e66d8c5423cd25ed0d291f1c2bad",
     "@tsconfig/ember": "^3.0.9",
     "@typescript-eslint/eslint-plugin": "^8.25.0",
     "babel-loader": "^8.3.0",

--- a/embeddable-say-editor/package.json
+++ b/embeddable-say-editor/package.json
@@ -56,7 +56,7 @@
     "@glint/template": "^1.5.2",
     "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-rdfa-editor": "11.3.0",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "28.2.0-dev.85da5ade4142e66d8c5423cd25ed0d291f1c2bad",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "29.0.0",
     "@tsconfig/ember": "^3.0.9",
     "@typescript-eslint/eslint-plugin": "^8.25.0",
     "babel-loader": "^8.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,8 +127,8 @@ importers:
         specifier: 11.3.0
         version: 11.3.0(6zonndjbxwrvaluwxcycbqbemq)
       '@lblod/ember-rdfa-editor-lblod-plugins':
-        specifier: 28.1.0
-        version: 28.1.0(fnk4xsjsgnsjkwtrfhoazlnlxq)
+        specifier: 28.2.0-dev.85da5ade4142e66d8c5423cd25ed0d291f1c2bad
+        version: 28.2.0-dev.85da5ade4142e66d8c5423cd25ed0d291f1c2bad(fnk4xsjsgnsjkwtrfhoazlnlxq)
       '@tsconfig/ember':
         specifier: ^3.0.9
         version: 3.0.9
@@ -1902,8 +1902,8 @@ packages:
       '@appuniversum/ember-appuniversum': ^2.0.0 || ^3.0.0
       ember-source: ^4.0.0
 
-  '@lblod/ember-rdfa-editor-lblod-plugins@28.1.0':
-    resolution: {integrity: sha512-iS3hrPCLlr7VAQy+Lt7E8KU4ihhitZLpXMeoE+OXsYh/EDWKJXz3Y32iZ5FbS7vOKZwe8s2b+LZVoY0NF213Kg==}
+  '@lblod/ember-rdfa-editor-lblod-plugins@28.2.0-dev.85da5ade4142e66d8c5423cd25ed0d291f1c2bad':
+    resolution: {integrity: sha512-NxyYBTkVmkedk2fJy7h6M1Spe/OEsgpAIATWlKomgCBQl5blSM70rfsI8QtgllbBprhajKuP0H6EfGyaOFUMuQ==}
     engines: {node: '>= 18'}
     peerDependencies:
       '@appuniversum/ember-appuniversum': ^3.5.0
@@ -12454,7 +12454,7 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@lblod/ember-rdfa-editor-lblod-plugins@28.1.0(fnk4xsjsgnsjkwtrfhoazlnlxq)':
+  '@lblod/ember-rdfa-editor-lblod-plugins@28.2.0-dev.85da5ade4142e66d8c5423cd25ed0d291f1c2bad(fnk4xsjsgnsjkwtrfhoazlnlxq)':
     dependencies:
       '@appuniversum/ember-appuniversum': 3.8.0(smjpcym6solncpes2bgwll3u6a)
       '@babel/core': 7.25.2
@@ -13408,12 +13408,12 @@ snapshots:
   '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.91.0)':
     dependencies:
       webpack: 5.91.0(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@4.15.1)(webpack@5.91.0)
+      webpack-cli: 5.1.4(webpack@5.91.0)
 
   '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.91.0)':
     dependencies:
       webpack: 5.91.0(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@4.15.1)(webpack@5.91.0)
+      webpack-cli: 5.1.4(webpack@5.91.0)
 
   '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack-dev-server@4.15.1)(webpack@5.91.0)':
     dependencies:
@@ -21970,7 +21970,7 @@ snapshots:
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     optionalDependencies:
-      webpack-cli: 5.1.4(webpack-dev-server@4.15.1)(webpack@5.91.0)
+      webpack-cli: 5.1.4(webpack@5.91.0)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,8 +127,8 @@ importers:
         specifier: 11.3.0
         version: 11.3.0(6zonndjbxwrvaluwxcycbqbemq)
       '@lblod/ember-rdfa-editor-lblod-plugins':
-        specifier: 28.2.0-dev.85da5ade4142e66d8c5423cd25ed0d291f1c2bad
-        version: 28.2.0-dev.85da5ade4142e66d8c5423cd25ed0d291f1c2bad(fnk4xsjsgnsjkwtrfhoazlnlxq)
+        specifier: 29.0.0
+        version: 29.0.0(fnk4xsjsgnsjkwtrfhoazlnlxq)
       '@tsconfig/ember':
         specifier: ^3.0.9
         version: 3.0.9
@@ -1899,8 +1899,8 @@ packages:
       '@appuniversum/ember-appuniversum': ^2.0.0 || ^3.0.0
       ember-source: ^4.0.0
 
-  '@lblod/ember-rdfa-editor-lblod-plugins@28.2.0-dev.85da5ade4142e66d8c5423cd25ed0d291f1c2bad':
-    resolution: {integrity: sha512-NxyYBTkVmkedk2fJy7h6M1Spe/OEsgpAIATWlKomgCBQl5blSM70rfsI8QtgllbBprhajKuP0H6EfGyaOFUMuQ==}
+  '@lblod/ember-rdfa-editor-lblod-plugins@29.0.0':
+    resolution: {integrity: sha512-gpma762YbF4w+jGzX7/ATJONN5CUBwwqjP/16sQNcWVuonvv4t53ZePqIQK9oPD552oS4bvG8rSt4EYV+Qw7xQ==}
     engines: {node: '>= 18'}
     peerDependencies:
       '@appuniversum/ember-appuniversum': ^3.5.0
@@ -12451,7 +12451,7 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@lblod/ember-rdfa-editor-lblod-plugins@28.2.0-dev.85da5ade4142e66d8c5423cd25ed0d291f1c2bad(fnk4xsjsgnsjkwtrfhoazlnlxq)':
+  '@lblod/ember-rdfa-editor-lblod-plugins@29.0.0(fnk4xsjsgnsjkwtrfhoazlnlxq)':
     dependencies:
       '@appuniversum/ember-appuniversum': 3.8.0(smjpcym6solncpes2bgwll3u6a)
       '@babel/core': 7.25.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -286,9 +286,6 @@ importers:
         specifier: workspace:*
         version: link:../embeddable-say-editor
     devDependencies:
-      copy-webpack-plugin:
-        specifier: ^12.0.2
-        version: 12.0.2(webpack@5.91.0)
       cypress:
         specifier: ^13.6.2
         version: 13.7.2

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -13,7 +13,6 @@
     "lint:js:fix": "eslint . --fix"
   },
   "devDependencies": {
-    "copy-webpack-plugin": "^12.0.2",
     "cypress": "^13.6.2",
     "eslint": "^8.37.0",
     "eslint-plugin-cypress": "^2.15.1",

--- a/test-app/webpack.config.js
+++ b/test-app/webpack.config.js
@@ -1,7 +1,6 @@
 const path = require('path');
 const HtmlWebPackPlugin = require('html-webpack-plugin');
 const pages = require('./pages');
-const CopyPlugin = require('copy-webpack-plugin');
 
 const htmlPlugins = [];
 const entries = {};
@@ -40,20 +39,6 @@ module.exports = (environment) => {
       filename: '[name].js',
       path: path.resolve(__dirname, 'dist'),
     },
-    plugins: [
-      ...htmlPlugins,
-      new CopyPlugin({
-        patterns: [
-          {
-            from: 'assets/images/**/*',
-            context: path.resolve(
-              __dirname,
-              'node_modules/@lblod/embeddable-say-editor/dist',
-            ),
-            to: path.resolve(__dirname, 'dist'),
-          },
-        ],
-      }),
-    ],
+    plugins: [...htmlPlugins],
   };
 };


### PR DESCRIPTION
## Overview
Latest plugins including bundled map markers.

##### connected issues and PRs:
Part of https://binnenland.atlassian.net/browse/GN-5507
Uses https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/556

### Setup
N/A

### How to test/reproduce
To test you can block the assets used for the default icon. You can do this in the devtools. In FF, it's in the network tab, to the right of the url filter box, the 'cancel' icon. The URLs to block are:

```
http://localhost:8080/assets/images/marker-icon-2x.png
http://localhost:8080/assets/images/marker-shadow.png
```

With this change, the icons should still show.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations