### PR TITLE
Add place description config and slash commands

### DIFF
--- a/.changeset/hot-grapes-sort.md
+++ b/.changeset/hot-grapes-sort.md
@@ -1,0 +1,5 @@
+---
+"@lblod/embeddable-say-editor": minor
+---
+
+Add configuration for place description (old location variable) context actions

--- a/.changeset/modern-dragons-sort.md
+++ b/.changeset/modern-dragons-sort.md
@@ -1,0 +1,5 @@
+---
+"@lblod/embeddable-say-editor": minor
+---
+
+Add plugin to display placeholder prompts for empty blocks to core plugins

--- a/.changeset/pink-trains-call.md
+++ b/.changeset/pink-trains-call.md
@@ -1,0 +1,5 @@
+---
+"@lblod/embeddable-say-editor": patch
+---
+
+Update [@lblod/ember-rdfa-editor-lblod-plugins to v38.0.1](https://github.com/lblod/ember-rdfa-editor-lblod-plugins/releases/tag/v38.0.1)

--- a/.changeset/plenty-baths-hang.md
+++ b/.changeset/plenty-baths-hang.md
@@ -1,0 +1,5 @@
+---
+"@lblod/embeddable-say-editor": patch
+---
+
+Move editable node prose plugin to core plugins to support other functionality

--- a/.changeset/slimy-months-draw.md
+++ b/.changeset/slimy-months-draw.md
@@ -1,0 +1,5 @@
+---
+"@lblod/embeddable-say-editor": minor
+---
+
+Add slash command support to the editor if context actions are configured in any plugin

--- a/docs/plugins/ar-design-plugin.md
+++ b/docs/plugins/ar-design-plugin.md
@@ -2,6 +2,11 @@
 
 Add annotated traffic signaling designs to an _aanvullend reglement_ based on data returned by the passed query function.
 
+> [!NOTE]
+> This plugin requires the `variable` plugin in order to allow variables contained within the
+> designs to be rendered and set correctly. This in practice means that without this, most designs
+> will display an error on the preview and will not be insertable.
+
 ## Setup
 
 ```javascript

--- a/docs/plugins/location-plugin.md
+++ b/docs/plugins/location-plugin.md
@@ -16,6 +16,7 @@ const editor = await renderEditor({
       defaultAddressUriRoot: "https://example.net/id/adres/",
       defaultMunicipality: "Gent",
       locationTypes: ["address", "place", "area"],
+      openModalOnInsert: false,
       // both below options are optional, see below for explanation
       // you'll likely only need one or the other
       explicitSubjectToLinkTo: "https://my-namespace.net/decisions/12341234",
@@ -33,6 +34,9 @@ The plugin expects the following configuration options:
 - `defaultAddressUriRoot` (default: 'https://example.net/id/adres/')
 - `defaultMunicipality` (default: none)
 - `locationTypes` (default: `['address', 'place', 'area']`)
+- `openModalOnInsert` (default: false) - when `false`, inserts a placeholder, which can be used with
+  the context actions menu, or using the sidebar button to open the modal. When `true` opens the
+  modal immediately.
 - `explicitSubjectToLinkTo` (default: none)
 - `subjectTypesToLinkTo` (default: none)
 

--- a/docs/plugins/roadsign-regulation-plugin.md
+++ b/docs/plugins/roadsign-regulation-plugin.md
@@ -2,6 +2,11 @@
 
 Add annotated _mobiliteitsmaatregelen_ from a specified registry, which will most likely be using the [public facing sparql endpoint](https://register.mobiliteit.vlaanderen.be/sparql) of [the roadsign registry](https://register.mobiliteit.vlaanderen.be). This data is maintained by experts at [MOW Vlaanderen](https://www.vlaanderen.be/departement-mobiliteit-en-openbare-werken).
 
+> [!NOTE]
+> This plugin requires the `variable` plugin in order to allow variables contained within the
+> regulations to be rendered and set correctly. This in practice means that without this, most
+> regulations will display an error in the console and will not be insertable.
+
 ## Setup
 
 ```javascript

--- a/embeddable-say-editor/app/components/simple-editor.gts
+++ b/embeddable-say-editor/app/components/simple-editor.gts
@@ -5,7 +5,7 @@ import { service } from '@ember/service';
 import { modifier } from 'ember-modifier';
 
 import { SayController } from '@lblod/ember-rdfa-editor';
-
+import ContextualActionsContainer from '@lblod/ember-rdfa-editor/components/plugins/contextual-actions/container';
 import { getActiveEditableNode } from '@lblod/ember-rdfa-editor/plugins/_private/editable-node';
 import EditorContainer from '@lblod/ember-rdfa-editor/components/editor-container';
 import Editor from '@lblod/ember-rdfa-editor/components/editor';
@@ -188,6 +188,10 @@ export default class SimpleEditorComponent extends Component<Sig> {
               />
               {{#if this.controller}}
                 <TableTooltip @controller={{this.controller}} />
+                <ContextualActionsContainer
+                  @controller={{this.controller}}
+                  @getGroups={{s.contextualActionGroupGetters}}
+                />
               {{/if}}
             </:default>
             <:sidebarRight as |container|>

--- a/embeddable-say-editor/app/plugins/definitions/ar-design.gts
+++ b/embeddable-say-editor/app/plugins/definitions/ar-design.gts
@@ -109,18 +109,20 @@ const arDesignTest = () =>
   });
 
 function processDocumentHelper(editorSetup: EditorSetup) {
-  return (html: Parameters<typeof _processDocumentHeadlesslyFromEditorSetup>[0], generator: Parameters<typeof _processDocumentHeadlesslyFromEditorSetup>[1]) => _processDocumentHeadlesslyFromEditorSetup(html, generator, editorSetup);
+  return (
+    html: Parameters<typeof _processDocumentHeadlesslyFromEditorSetup>[0],
+    generator: Parameters<typeof _processDocumentHeadlesslyFromEditorSetup>[1],
+  ) => _processDocumentHeadlesslyFromEditorSetup(html, generator, editorSetup);
 }
 
-export const arDesignWidget: TOC<WidgetSignature<'arDesign'>> =
-  <template>
-    <SidebarWidget
-      @controller={{@controller}}
-      @designQuery={{@setup.pluginSpecs.arDesign.config.designQuery}}
-      @processDocumentHeadlessly={{processDocumentHelper @setup}}
-      @decisionContext={{@setup.pluginSpecs.arDesign.config.decisionContext}}
-    />
-  </template>;
+export const arDesignWidget: TOC<WidgetSignature<'arDesign'>> = <template>
+  <SidebarWidget
+    @controller={{@controller}}
+    @designQuery={{@setup.pluginSpecs.arDesign.config.designQuery}}
+    @processDocumentHeadlessly={{processDocumentHelper @setup}}
+    @decisionContext={{@setup.pluginSpecs.arDesign.config.decisionContext}}
+  />
+</template>;
 
 const defaultConfig: ArDesignPluginOptions = {
   designQuery: arDesignTest,

--- a/embeddable-say-editor/app/plugins/definitions/article-structure.gts
+++ b/embeddable-say-editor/app/plugins/definitions/article-structure.gts
@@ -5,7 +5,10 @@ import {
   structureViewWithConfig,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/structure-plugin/node';
 import type { StructurePluginOptions } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/structure-plugin/structure-types';
-import type { NodeViewConstructor, SayController } from '@lblod/ember-rdfa-editor';
+import type {
+  NodeViewConstructor,
+  SayController,
+} from '@lblod/ember-rdfa-editor';
 import type { WidgetSignature } from '../widgets.ts';
 import type { PluginInitializer } from '../embedded-plugin.ts';
 

--- a/embeddable-say-editor/app/plugins/definitions/besluit.gts
+++ b/embeddable-say-editor/app/plugins/definitions/besluit.gts
@@ -8,7 +8,10 @@ import {
   structureWithConfig,
   structureViewWithConfig,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/structure-plugin/node';
-import type { NodeViewConstructor, SayController } from '@lblod/ember-rdfa-editor';
+import type {
+  NodeViewConstructor,
+  SayController,
+} from '@lblod/ember-rdfa-editor';
 
 const name = 'besluit';
 

--- a/embeddable-say-editor/app/plugins/definitions/core/core.ts
+++ b/embeddable-say-editor/app/plugins/definitions/core/core.ts
@@ -36,12 +36,18 @@ import {
   orderedListWithConfig,
 } from '@lblod/ember-rdfa-editor/plugins/list';
 import { headingWithConfig } from '@lblod/ember-rdfa-editor/plugins/heading';
-import { inlineRdfaWithConfig, inlineRdfaWithConfigView } from '@lblod/ember-rdfa-editor/nodes/inline-rdfa';
+import {
+  inlineRdfaWithConfig,
+  inlineRdfaWithConfigView,
+} from '@lblod/ember-rdfa-editor/nodes/inline-rdfa';
 import { BlockRDFaView } from '@lblod/ember-rdfa-editor/nodes/block-rdfa';
 import type { ProsePlugin } from '@lblod/ember-rdfa-editor';
 import { emptyBlockPlaceholder } from '@lblod/ember-rdfa-editor/plugins/empty-block-placeholder';
 import { editableNodePlugin } from '@lblod/ember-rdfa-editor/plugins/_private/editable-node';
-import type { EmbeddedPluginSpec, PluginInitializer } from '../../embedded-plugin.ts';
+import type {
+  EmbeddedPluginSpec,
+  PluginInitializer,
+} from '../../embedded-plugin.ts';
 import { coreToolbarWidgets } from './toolbar-widgets.gts';
 import { coreSidebarWidgets } from './sidebar-widgets.gts';
 
@@ -79,8 +85,12 @@ export const coreSetup = (({ options }) => {
     superscript,
   };
   const nodeViews: EmbeddedPluginSpec['nodeViews'] = {
-    inline_rdfa: (controller) => inlineRdfaWithConfigView({ rdfaAware: true })(controller),
-    block_rdfa: (controller) => (...args) => new BlockRDFaView(args, controller),
+    inline_rdfa: (controller) =>
+      inlineRdfaWithConfigView({ rdfaAware: true })(controller),
+    block_rdfa:
+      (controller) =>
+      (...args) =>
+        new BlockRDFaView(args, controller),
   };
   const prosePlugins: ProsePlugin[] = [
     firefoxCursorFix(),

--- a/embeddable-say-editor/app/plugins/definitions/core/core.ts
+++ b/embeddable-say-editor/app/plugins/definitions/core/core.ts
@@ -39,6 +39,7 @@ import { headingWithConfig } from '@lblod/ember-rdfa-editor/plugins/heading';
 import { inlineRdfaWithConfig, inlineRdfaWithConfigView } from '@lblod/ember-rdfa-editor/nodes/inline-rdfa';
 import { BlockRDFaView } from '@lblod/ember-rdfa-editor/nodes/block-rdfa';
 import type { ProsePlugin } from '@lblod/ember-rdfa-editor';
+import { emptyBlockPlaceholder } from '@lblod/ember-rdfa-editor/plugins/empty-block-placeholder';
 import type { EmbeddedPluginSpec, PluginInitializer } from '../../embedded-plugin.ts';
 import { coreToolbarWidgets } from './toolbar-widgets.gts';
 import { coreSidebarWidgets } from './sidebar-widgets.gts';
@@ -80,13 +81,14 @@ export const coreSetup = (({ options }) => {
     inline_rdfa: (controller) => inlineRdfaWithConfigView({ rdfaAware: true })(controller),
     block_rdfa: (controller) => (...args) => new BlockRDFaView(args, controller),
   };
-  const prosePlugins = [
+  const prosePlugins: ProsePlugin[] = [
     firefoxCursorFix(),
     lastKeyPressedPlugin,
     recreateUuidsOnPaste,
     createInvisiblesPlugin([hardBreak, paragraphInvisible, headingInvisible], {
       shouldShowInvisibles: false,
-    }) as ProsePlugin,
+    }),
+    emptyBlockPlaceholder(),
   ];
   return {
     name: 'core',

--- a/embeddable-say-editor/app/plugins/definitions/core/core.ts
+++ b/embeddable-say-editor/app/plugins/definitions/core/core.ts
@@ -40,6 +40,7 @@ import { inlineRdfaWithConfig, inlineRdfaWithConfigView } from '@lblod/ember-rdf
 import { BlockRDFaView } from '@lblod/ember-rdfa-editor/nodes/block-rdfa';
 import type { ProsePlugin } from '@lblod/ember-rdfa-editor';
 import { emptyBlockPlaceholder } from '@lblod/ember-rdfa-editor/plugins/empty-block-placeholder';
+import { editableNodePlugin } from '@lblod/ember-rdfa-editor/plugins/_private/editable-node';
 import type { EmbeddedPluginSpec, PluginInitializer } from '../../embedded-plugin.ts';
 import { coreToolbarWidgets } from './toolbar-widgets.gts';
 import { coreSidebarWidgets } from './sidebar-widgets.gts';
@@ -88,6 +89,9 @@ export const coreSetup = (({ options }) => {
     createInvisiblesPlugin([hardBreak, paragraphInvisible, headingInvisible], {
       shouldShowInvisibles: false,
     }),
+    // This plugin is now used by many parts of the editor internally, so is considered a core
+    // plugin. For example, context actions rely on it to get the active node.
+    editableNodePlugin(),
     emptyBlockPlaceholder(),
   ];
   return {

--- a/embeddable-say-editor/app/plugins/definitions/editable-rdfa.ts
+++ b/embeddable-say-editor/app/plugins/definitions/editable-rdfa.ts
@@ -1,7 +1,7 @@
-import { editableNodePlugin } from '@lblod/ember-rdfa-editor/plugins/_private/editable-node';
 import type { PluginInitializer } from '../embedded-plugin.ts';
 
 const name = 'rdfaEditor';
+/** This plugin is a no-op that is used to switch on developer features in the default sidebar */
 export const setupEditableRdfaPlugin = (() => {
-  return { name, prosePlugins: [editableNodePlugin()] };
+  return { name };
 }) satisfies PluginInitializer;

--- a/embeddable-say-editor/app/plugins/definitions/location.gts
+++ b/embeddable-say-editor/app/plugins/definitions/location.gts
@@ -3,6 +3,7 @@ import {
   osloLocationView,
   type LocationPluginConfig,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin/node';
+import { locationModalsPlugin } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin';
 import { mergeConfigs } from '../setup/defaults';
 import OSLOLocationInsert from '@lblod/ember-rdfa-editor-lblod-plugins/components/location-plugin/insert';
 import type { PluginInitializer } from '../embedded-plugin';
@@ -37,6 +38,7 @@ export const setupLocationPlugin = (({ options }) => {
     nodeViews: {
       oslo_location: (controller) => osloLocationView(config)(controller),
     },
+    prosePlugins: [locationModalsPlugin()],
     sidebarWidgets: { 'location:insert': locationInsert },
   };
 }) satisfies PluginInitializer;

--- a/embeddable-say-editor/app/plugins/definitions/location.gts
+++ b/embeddable-say-editor/app/plugins/definitions/location.gts
@@ -4,8 +4,10 @@ import {
   type LocationPluginConfig,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin/node';
 import { locationModalsPlugin } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin';
+import { getContextualActionGroups as locationActionsGroups } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin/contextual-actions';
 import { mergeConfigs } from '../setup/defaults';
 import OSLOLocationInsert from '@lblod/ember-rdfa-editor-lblod-plugins/components/location-plugin/insert';
+import OSLOLocationInsertPlaceholder from '@lblod/ember-rdfa-editor-lblod-plugins/components/location-plugin/insert-location-placeholder';
 import type { PluginInitializer } from '../embedded-plugin';
 import type { TOC } from '@ember/component/template-only';
 import type { WidgetSignature } from '../widgets';
@@ -16,6 +18,10 @@ export type LocationConfig = LocationPluginConfig & {
   locationTypes: Array<'address' | 'place' | 'area'>;
 };
 export const locationInsert: TOC<WidgetSignature<'location'>> = <template>
+  <OSLOLocationInsertPlaceholder
+    @controller={{@controller}}
+    @config={{@setup.pluginSpecs.location.config}}
+  />
   <OSLOLocationInsert
     @controller={{@controller}}
     @config={{@setup.pluginSpecs.location.config}}
@@ -39,6 +45,7 @@ export const setupLocationPlugin = (({ options }) => {
       oslo_location: (controller) => osloLocationView(config)(controller),
     },
     prosePlugins: [locationModalsPlugin()],
+    contextualActionGroupGetters: [locationActionsGroups()],
     sidebarWidgets: { 'location:insert': locationInsert },
   };
 }) satisfies PluginInitializer;

--- a/embeddable-say-editor/app/plugins/definitions/location.gts
+++ b/embeddable-say-editor/app/plugins/definitions/location.gts
@@ -7,26 +7,27 @@ import { locationModalsPlugin } from '@lblod/ember-rdfa-editor-lblod-plugins/plu
 import { getContextualActionGroups as locationActionsGroups } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin/contextual-actions';
 import { mergeConfigs } from '../setup/defaults';
 import OSLOLocationInsert from '@lblod/ember-rdfa-editor-lblod-plugins/components/location-plugin/insert';
-import OSLOLocationInsertPlaceholder from '@lblod/ember-rdfa-editor-lblod-plugins/components/location-plugin/insert-location-placeholder';
 import type { PluginInitializer } from '../embedded-plugin';
 import type { TOC } from '@ember/component/template-only';
 import type { WidgetSignature } from '../widgets';
+
+const not = (val: boolean | undefined) => !val;
 
 const name = 'location';
 export type LocationConfig = LocationPluginConfig & {
   defaultMunicipality?: string;
   locationTypes: Array<'address' | 'place' | 'area'>;
+  openModalOnInsert?: boolean;
 };
 export const locationInsert: TOC<WidgetSignature<'location'>> = <template>
-  <OSLOLocationInsertPlaceholder
-    @controller={{@controller}}
-    @config={{@setup.pluginSpecs.location.config}}
-  />
   <OSLOLocationInsert
     @controller={{@controller}}
     @config={{@setup.pluginSpecs.location.config}}
     @defaultMunicipality={{@setup.pluginSpecs.location.config.defaultMunicipality}}
     @locationTypes={{@setup.pluginSpecs.location.config.locationTypes}}
+    @insertPlaceholder={{not
+      @setup.pluginSpecs.location.config.openModalOnInsert
+    }}
   />
 </template>;
 const defaultConfig: LocationConfig = {

--- a/embeddable-say-editor/app/plugins/definitions/variable.gts
+++ b/embeddable-say-editor/app/plugins/definitions/variable.gts
@@ -32,6 +32,7 @@ import DateEdit from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable
 import LocationEdit from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/location/edit';
 import AddressEdit from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/address/edit';
 import type { LocationEditOptions } from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/location/edit';
+import { getContextualActionGroups as placeDescriptionActionGroups } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/contextual-actions';
 import type { PluginInitializer } from '../embedded-plugin';
 import { mergeConfigs } from '../setup/defaults';
 import type { WidgetSignature } from '../widgets';
@@ -129,7 +130,7 @@ const defaultConfig = (intl: IntlService): VariablePluginConfig => {
     edit: {
       enable: true,
       location: {
-        endpoint: 'https://dev.roadsigns.lblod.info',
+        endpoint: 'https://dev.roadsigns.lblod.info/sparql',
         zonalLocationCodelistUri:
           'http://lblod.data.gift/concept-schemes/62331E6900730AE7B99DF7EF',
         nonZonalLocationCodelistUri:
@@ -186,6 +187,9 @@ export const setupVariablePlugin = (({ options, intl }) => {
     config,
     nodes: variableNodes,
     nodeViews: variableNodeViews,
+    contextualActionGroupGetters: [
+      placeDescriptionActionGroups(config.edit.location),
+    ],
     sidebarWidgets: {
       'variable:insert': variableInsert,
       'variable:edit': variableEdit,

--- a/embeddable-say-editor/app/plugins/embedded-plugin.ts
+++ b/embeddable-say-editor/app/plugins/embedded-plugin.ts
@@ -1,5 +1,9 @@
 import type IntlService from 'ember-intl/services/intl';
-import type { MarkSpec, NodeViewConstructor, ProsePlugin } from '@lblod/ember-rdfa-editor';
+import type {
+  MarkSpec,
+  NodeViewConstructor,
+  ProsePlugin,
+} from '@lblod/ember-rdfa-editor';
 import type { GetContextualActionGroups } from '@lblod/ember-rdfa-editor/plugins/contextual-actions';
 import type SayController from '@lblod/ember-rdfa-editor/core/say-controller';
 import type SayNodeSpec from '@lblod/ember-rdfa-editor/core/say-node-spec';

--- a/embeddable-say-editor/app/plugins/embedded-plugin.ts
+++ b/embeddable-say-editor/app/plugins/embedded-plugin.ts
@@ -1,3 +1,6 @@
+import type IntlService from 'ember-intl/services/intl';
+import type { MarkSpec, NodeViewConstructor, ProsePlugin } from '@lblod/ember-rdfa-editor';
+import type { GetContextualActionGroups } from '@lblod/ember-rdfa-editor/plugins/contextual-actions';
 import type SayController from '@lblod/ember-rdfa-editor/core/say-controller';
 import type SayNodeSpec from '@lblod/ember-rdfa-editor/core/say-node-spec';
 import type { Kebab } from '../utils/type-utils.ts';
@@ -16,8 +19,6 @@ import type {
   SidebarWidgets,
   ToolbarWidgets,
 } from './plugin-registry';
-import type IntlService from 'ember-intl/services/intl';
-import type { MarkSpec, NodeViewConstructor, ProsePlugin } from '@lblod/ember-rdfa-editor';
 import type {
   EditorSetup,
   InitializedPluginName,
@@ -46,6 +47,7 @@ export interface EmbeddedPluginSpec {
   >;
   prosePlugins?: ProsePlugin[];
   config?: unknown;
+  contextualActionGroupGetters?: GetContextualActionGroups;
   toolbarWidgets?: ToolbarWidgetMap;
   sidebarWidgets?: {
     [K in

--- a/embeddable-say-editor/app/plugins/setup/setup-plugins.ts
+++ b/embeddable-say-editor/app/plugins/setup/setup-plugins.ts
@@ -119,10 +119,12 @@ export function setupPlugins(args: PluginInitArgs): EditorSetup {
     }
   }
   if (contextualActionGroupGetters.length) {
-    prosePlugins.push(slashCommandsPlugin({
-      intl: args.intl,
-      getGroups: contextualActionGroupGetters,
-    }));
+    prosePlugins.push(
+      slashCommandsPlugin({
+        intl: args.intl,
+        getGroups: contextualActionGroupGetters,
+      }),
+    );
   }
   const schema = new Schema({ nodes, marks });
   let result = {

--- a/embeddable-say-editor/app/plugins/setup/setup-plugins.ts
+++ b/embeddable-say-editor/app/plugins/setup/setup-plugins.ts
@@ -6,6 +6,7 @@ import {
   type SayController,
 } from '@lblod/ember-rdfa-editor';
 import type SayNodeSpec from '@lblod/ember-rdfa-editor/core/say-node-spec';
+import type { GetContextualActionGroups } from '@lblod/ember-rdfa-editor/plugins/contextual-actions';
 import type {
   EmbeddedPluginSpec,
   KebabPluginName,
@@ -21,6 +22,7 @@ import type {
 import { defaultToolbar } from './default-toolbar.ts';
 import { defaultSidebar } from './default-sidebar.ts';
 import { PLUGIN_MAP } from '../plugin-registry';
+
 type EnsuredSpecs<
   S extends PluginSpecs,
   N extends PluginName | void,
@@ -36,6 +38,7 @@ export type EditorSetup<N extends PluginName | void = void> = {
   prosePlugins: ProsePlugin[];
   toolbarConfig: ToolbarConfig;
   sidebarConfig: SidebarConfig;
+  contextualActionGroupGetters: GetContextualActionGroups;
   widgetMaps: {
     toolbar: Record<string, WidgetComponent>;
     sidebar: Record<string, WidgetComponent>;
@@ -71,6 +74,7 @@ export function setupPlugins(args: PluginInitArgs): EditorSetup {
   ];
   let toolbarWidgets: Record<string, WidgetComponent> = {};
   let sidebarWidgets: Record<string, WidgetComponent> = {};
+  let contextualActionGroupGetters: GetContextualActionGroups = [];
 
   const realSpecs = pluginsWithCore.map((name) => ({
     name: camelize(name),
@@ -109,6 +113,12 @@ export function setupPlugins(args: PluginInitArgs): EditorSetup {
         ...(spec.sidebarWidgets as Record<string, WidgetComponent>),
       };
     }
+    if (spec.contextualActionGroupGetters) {
+      contextualActionGroupGetters = [
+        ...contextualActionGroupGetters,
+        ...spec.contextualActionGroupGetters,
+      ];
+    }
   }
   const schema = new Schema({ nodes, marks });
   let result = {
@@ -127,6 +137,7 @@ export function setupPlugins(args: PluginInitArgs): EditorSetup {
     },
     sidebarConfig: sidebar ?? defaultSidebar(args),
     toolbarConfig: toolbar ?? defaultToolbar(args),
+    contextualActionGroupGetters: contextualActionGroupGetters,
     widgetMaps: { sidebar: sidebarWidgets, toolbar: toolbarWidgets },
   };
 

--- a/embeddable-say-editor/app/plugins/setup/setup-plugins.ts
+++ b/embeddable-say-editor/app/plugins/setup/setup-plugins.ts
@@ -22,6 +22,7 @@ import type {
 import { defaultToolbar } from './default-toolbar.ts';
 import { defaultSidebar } from './default-sidebar.ts';
 import { PLUGIN_MAP } from '../plugin-registry';
+import { slashCommandsPlugin } from '@lblod/ember-rdfa-editor/plugins/slash-commands/index';
 
 type EnsuredSpecs<
   S extends PluginSpecs,
@@ -74,7 +75,7 @@ export function setupPlugins(args: PluginInitArgs): EditorSetup {
   ];
   let toolbarWidgets: Record<string, WidgetComponent> = {};
   let sidebarWidgets: Record<string, WidgetComponent> = {};
-  let contextualActionGroupGetters: GetContextualActionGroups = [];
+  const contextualActionGroupGetters: GetContextualActionGroups = [];
 
   const realSpecs = pluginsWithCore.map((name) => ({
     name: camelize(name),
@@ -114,11 +115,14 @@ export function setupPlugins(args: PluginInitArgs): EditorSetup {
       };
     }
     if (spec.contextualActionGroupGetters) {
-      contextualActionGroupGetters = [
-        ...contextualActionGroupGetters,
-        ...spec.contextualActionGroupGetters,
-      ];
+      contextualActionGroupGetters.push(...spec.contextualActionGroupGetters);
     }
+  }
+  if (contextualActionGroupGetters.length) {
+    prosePlugins.push(slashCommandsPlugin({
+      intl: args.intl,
+      getGroups: contextualActionGroupGetters,
+    }));
   }
   const schema = new Schema({ nodes, marks });
   let result = {

--- a/embeddable-say-editor/app/utils/_private/headless-document-internals.ts
+++ b/embeddable-say-editor/app/utils/_private/headless-document-internals.ts
@@ -40,7 +40,10 @@ export function _doProcessDocument(
   return div.innerHTML;
 }
 
-export function _getState(html: string, { schema, prosePlugins }: EditorSetup): EditorState {
+export function _getState(
+  html: string,
+  { schema, prosePlugins }: EditorSetup,
+): EditorState {
   const parser = ProseParser.fromSchema(schema);
   const doc = htmlToDoc(html, {
     schema: schema,

--- a/embeddable-say-editor/app/utils/process-document-headlessly.ts
+++ b/embeddable-say-editor/app/utils/process-document-headlessly.ts
@@ -3,7 +3,10 @@ import { EditorState } from '@lblod/ember-rdfa-editor';
 import type { TransactionCombinatorResult } from '@lblod/ember-rdfa-editor/utils/transaction-utils';
 import type { EditorOptions } from '../plugins/embedded-plugin.ts';
 import { setupPlugins } from '../plugins/setup/setup-plugins.ts';
-import { _doProcessDocument, _getState } from './_private/headless-document-internals.ts';
+import {
+  _doProcessDocument,
+  _getState,
+} from './_private/headless-document-internals.ts';
 
 export function processDocumentHeadlessly(
   html: string,
@@ -16,7 +19,10 @@ export function processDocumentHeadlessly(
   return _doProcessDocument(transactionGenerator, state);
 }
 
-function getStateFromConfig(html: string, editorConfig: EditorOptions): EditorState {
+function getStateFromConfig(
+  html: string,
+  editorConfig: EditorOptions,
+): EditorState {
   // We mock the intl service as we don't have it available in this context and we don't need it
   const editorSetup = setupPlugins({
     intl: { t: () => '' } as unknown as IntlService,

--- a/embeddable-say-editor/package.json
+++ b/embeddable-say-editor/package.json
@@ -103,7 +103,7 @@
     "@glint/ember-tsc": "^1.8.1",
     "@lblod/ember-environment-banner": "^0.6.0",
     "@lblod/ember-rdfa-editor": "13.13.0",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "37.3.0",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "38.0.1",
     "@lblod/say-ar-design-plugin": "3.0.0",
     "@lblod/say-roadsign-regulation-plugin": "3.0.0",
     "@types/leaflet": "^1.9.17",

--- a/embeddable-say-editor/test-app/cipal-plugins/cipal-plugins.ts
+++ b/embeddable-say-editor/test-app/cipal-plugins/cipal-plugins.ts
@@ -24,6 +24,7 @@ const options: UserPluginOptions = {
     defaultAddressUriRoot: 'https://example.net/id/adres/',
     explicitSubjectToLinkTo: 'https://example.net/decision-uri',
     defaultMunicipality: 'Gent',
+    openModalOnInsert: true,
   },
   ui: {
     expandInsertMenu: true,

--- a/embeddable-say-editor/test-app/multiple-growing-editors/multiple-growing-editors.ts
+++ b/embeddable-say-editor/test-app/multiple-growing-editors/multiple-growing-editors.ts
@@ -5,7 +5,12 @@ import type {
 } from '../../app/plugins/embedded-plugin.ts';
 import { router } from '../router.ts';
 
-const plugins: KebabPluginName[] = ['besluit', 'lpdc', 'roadsign-regulation', 'variable'];
+const plugins: KebabPluginName[] = [
+  'besluit',
+  'lpdc',
+  'roadsign-regulation',
+  'variable',
+];
 const decisionUri = 'http://example.org/besluit/12345';
 const decisionType =
   'https://data.vlaanderen.be/id/concept/BesluitType/0d1278af-b69e-4152-a418-ec5cfd1c7d0b';

--- a/embeddable-say-editor/test-app/multiple-growing-editors/multiple-growing-editors.ts
+++ b/embeddable-say-editor/test-app/multiple-growing-editors/multiple-growing-editors.ts
@@ -5,7 +5,7 @@ import type {
 } from '../../app/plugins/embedded-plugin.ts';
 import { router } from '../router.ts';
 
-const plugins: KebabPluginName[] = ['besluit', 'lpdc', 'roadsign-regulation'];
+const plugins: KebabPluginName[] = ['besluit', 'lpdc', 'roadsign-regulation', 'variable'];
 const decisionUri = 'http://example.org/besluit/12345';
 const decisionType =
   'https://data.vlaanderen.be/id/concept/BesluitType/0d1278af-b69e-4152-a418-ec5cfd1c7d0b';

--- a/embeddable-say-editor/test-app/shared-config.ts
+++ b/embeddable-say-editor/test-app/shared-config.ts
@@ -43,6 +43,7 @@ export const pluginDemoConfig: Omit<RenderEditorOptions, 'element'> &
     },
     location: {
       locationTypes: ['address', 'place'],
+      openModalOnInsert: false,
     },
     arDesign: {},
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,8 +108,8 @@ importers:
         specifier: 13.13.0
         version: 13.13.0(093d873b706647876b67b6cf78f43e4c)
       '@lblod/ember-rdfa-editor-lblod-plugins':
-        specifier: 37.3.0
-        version: 37.3.0(patch_hash=1d7a1dd5b51928e0cddcc2b22711c90af49e100f33aec3a96e9e3d67ad305e03)(38a4c4f0363427b87b4ed63e11aac9d5)
+        specifier: 38.0.1
+        version: 38.0.1(patch_hash=1d7a1dd5b51928e0cddcc2b22711c90af49e100f33aec3a96e9e3d67ad305e03)(38a4c4f0363427b87b4ed63e11aac9d5)
       '@lblod/say-ar-design-plugin':
         specifier: 3.0.0
         version: 3.0.0(d39daedeecc158dffb17493523eec352)
@@ -2074,14 +2074,14 @@ packages:
       '@appuniversum/ember-appuniversum': ^2.0.0 || ^3.0.0
       ember-source: ^4.0.0 || ^5.0.0
 
-  '@lblod/ember-rdfa-editor-lblod-plugins@37.3.0':
-    resolution: {integrity: sha512-HEsFuUIDorIMhnY2aFUpEo+VQDHL+5hmZGQT65EVZv0Y02FwGcGEd6yc2B8LNfxKdaHuIqegUf1PJuCib8MFzA==}
+  '@lblod/ember-rdfa-editor-lblod-plugins@38.0.1':
+    resolution: {integrity: sha512-BTs0FKFGdkgr/TbUdQdOedKG33QsrAaeW8OgwtZSRDYjrBf6iIaTb2olU+bajHAN1R3z5VHh0vzq0rmW/M1M8g==}
     engines: {node: '>= 18'}
     peerDependencies:
       '@appuniversum/ember-appuniversum': ^3.12.0
       '@ember/string': 4.0.1
       '@glint/template': ^1.4.0
-      '@lblod/ember-rdfa-editor': ^13.10.0
+      '@lblod/ember-rdfa-editor': ^13.12.0
       ember-concurrency: ^4.0.2
       ember-element-helper: ^0.8.6
       ember-intl: ^7.0.0
@@ -12089,7 +12089,7 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@lblod/ember-rdfa-editor-lblod-plugins@37.3.0(patch_hash=1d7a1dd5b51928e0cddcc2b22711c90af49e100f33aec3a96e9e3d67ad305e03)(38a4c4f0363427b87b4ed63e11aac9d5)':
+  '@lblod/ember-rdfa-editor-lblod-plugins@38.0.1(patch_hash=1d7a1dd5b51928e0cddcc2b22711c90af49e100f33aec3a96e9e3d67ad305e03)(38a4c4f0363427b87b4ed63e11aac9d5)':
     dependencies:
       '@appuniversum/ember-appuniversum': https://raw.githubusercontent.com/abeforgit/ember-appuniversum/refs/heads/fix/local-scoped-queryselect/appuniversum-ember-appuniversum-3.17.0.tgz(@ember/test-helpers@4.0.5(@babel/core@7.29.7)(@glint/template@1.7.8)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.8)(rsvp@4.8.5)(webpack@5.105.4(postcss@8.5.8))))(@glimmer/component@2.0.0)(@glint/template@1.7.8)(ember-basic-dropdown@8.11.0(patch_hash=32d0ca6074742b7542b79098a075ec9e093646363f297ed83f067e56968957c4)(@babel/core@7.29.7)(@ember/string@4.0.1)(@ember/test-helpers@4.0.5(@babel/core@7.29.7)(@glint/template@1.7.8)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.8)(rsvp@4.8.5)(webpack@5.105.4(postcss@8.5.8))))(@glimmer/component@2.0.0)(@glint/template@1.7.8)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.8)(rsvp@4.8.5)(webpack@5.105.4(postcss@8.5.8))))(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.8)(rsvp@4.8.5)(webpack@5.105.4(postcss@8.5.8)))(tracked-built-ins@3.4.0(@babel/core@7.29.7))(webpack@5.105.4(postcss@8.5.8))
       '@babel/core': 7.29.7


### PR DESCRIPTION
## Overview
This was indeed very easy and nice to enable this new fancy feature for embeddable users. The variable plugin now includes the contextual actions and slash commands are enabled if any plugin configures actions.

##### connected issues and PRs:
Part of [binnenland.atlassian.net/browse/GN-6155](https://binnenland.atlassian.net/browse/GN-6155)
Made to (in order to make reviews easier): https://github.com/lblod/frontend-embeddable-notule-editor/pull/292

### Setup
N/A

### How to test/reproduce
The ar-design and roadsign regulation insert buttons insert correctly and the variables within them (including place description) work correctly.

### Challenges/uncertainties
N/A

### Checks PR readiness

- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
